### PR TITLE
Remove unique timetable names

### DIFF
--- a/src/controllers/timetable/createTimetable.ts
+++ b/src/controllers/timetable/createTimetable.ts
@@ -49,47 +49,8 @@ export const createTimetable = async (req: Request, res: Response) => {
       return res.status(404).json({ message: "User not found" });
     }
 
-    let timetablesWhereDraftInName: Timetable[] = [];
-
-    try {
-      timetablesWhereDraftInName = await timetableRepository
-        .createQueryBuilder("timetable")
-        .where("timetable.authorId = :author", { author: author.id })
-        .andWhere("timetable.name like :name", { name: "Draft %" })
-        .getMany();
-    } catch (err: any) {
-      // will replace the console.log with a logger when we have one
-      console.log("Error while querying for draft timetables: ", err.message);
-
-      res.status(500).json({ message: "Internal Server Error" });
-    }
-
-    let draftNames = timetablesWhereDraftInName.map(
-      (timetable) => timetable.name
-    );
-
-    draftNames = draftNames.filter((draftName) => {
-      const secondWord = draftName.split(" ")[1];
-      return !isNaN(parseInt(secondWord));
-    });
-
-    draftNames = draftNames.sort((a, b) => {
-      const aDraftName = parseInt(a.split(" ")[1]);
-      const bDraftName = parseInt(b.split(" ")[1]);
-      return aDraftName - bDraftName;
-    });
-
-    if (draftNames.length === 0) {
-      console.log("No draft timetable found");
-      draftNames.push("Draft 0");
-    }
-
-    const latestDraftName = parseInt(
-      draftNames[draftNames.length - 1].split(" ")[1]
-    );
-
     // new timetable default properties
-    const name: string = `Draft ${latestDraftName + 1}`;
+    const name: string = "Untitled Timetable";
     const degrees: DegreeEnum[] = author.degrees;
     const isPrivate: boolean = true;
     const isDraft: boolean = true;
@@ -102,7 +63,7 @@ export const createTimetable = async (req: Request, res: Response) => {
     const lastUpdated: Date = new Date();
 
     try {
-      const timetable: Timetable = await timetableRepository.create({
+      const timetable: Timetable = timetableRepository.create({
         author,
         name,
         degrees,

--- a/src/entity/Timetable.ts
+++ b/src/entity/Timetable.ts
@@ -14,7 +14,6 @@ import { User } from "./User";
 import { Section } from "./Section";
 
 @Entity()
-@Unique(["name", "author"])
 export class Timetable {
   @PrimaryGeneratedColumn("increment")
   id!: number;


### PR DESCRIPTION
- removed unique constraint for timetable names per user
- gave default name `Untitled Timetable`, for all new timetables