### PR TITLE
Fix permissions errors being caused due to usage of sockets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 POSTGRES_USER=""
+PGUSER="" # should be same as POSTGRES_USER
 POSTGRES_PASSWORD=""
-POSTGRES_DB=""
-POSTGRES_SOCKET="/var/run/postgresql" # Do not change this, it is required by postgres
+POSTGRES_DB="" # should be same as POSTGRES_USER for some reason
 NODE_ENV=""
 PROD_URL=""
 PORT=

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Check [.env.example](./.env.example) for an example env file. It can be arbitrar
 
 ```
 POSTGRES_USER="chrono"
+PGUSER="chrono" # should be same as POSTGRES_USER
 POSTGRES_PASSWORD="aSBrbm93IHdoYXQgeW91IGFyZQ=="
-POSTGRES_DB="chronofactorem"
-POSTGRES_SOCKET="/var/run/postgresql" # Do not change this, it is required by postgres
+POSTGRES_DB="chrono" # should be same as POSTGRES_USER for some reason
 NODE_ENV="development"
 PROD_URL="https://chrono.crux-bphc.com"
 PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: "postgres:15.3-bookworm"
     env_file:
       - .env
-    volumes:
-      - "./postgres/socket:${POSTGRES_SOCKET}"
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB}"]
       interval: 10s
@@ -22,5 +22,3 @@ services:
         condition: service_healthy
     ports:
       - "${PORT}:${PORT}"
-    volumes:
-      - "./postgres/socket:${POSTGRES_SOCKET}"

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -7,10 +7,10 @@ import { z } from "zod";
  */
 export const serverSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]),
+  PGUSER: z.string().min(1),
   POSTGRES_USER: z.string().min(1),
   POSTGRES_PASSWORD: z.string().min(1),
   POSTGRES_DB: z.string().min(1),
-  POSTGRES_SOCKET: z.string().min(1),
   PROD_URL: z.string().url().min(1),
   PORT: z.coerce.number().default(3000),
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -9,7 +9,7 @@ import { SearchHistory } from "./entity/SearchHistory";
 
 export const AppDataSource = new DataSource({
   type: "postgres",
-  url: `socket://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@${env.POSTGRES_SOCKET}?db=${env.POSTGRES_DB}`,
+  url: `postgres://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@db:5432?db=${env.POSTGRES_DB}`,
   synchronize: true,
   logging: false,
   entities: [User, Timetable, Course, Section, SearchHistory],


### PR DESCRIPTION
For some reason, some people have permission errors because of unix sockets, so we're moving back to using network ports for our db calls.

BREAKING CHANGES: .env now needs new values, go check README in this branch.