### PR TITLE
Add course codes to section roomTimes

### DIFF
--- a/src/controllers/timetable/addSection.ts
+++ b/src/controllers/timetable/addSection.ts
@@ -185,7 +185,7 @@ export const addSection = async (req: Request, res: Response) => {
   );
 
   const newTimes: string[] = section.roomTime.map(
-    (time) => course?.code + ":" + time.split(":")[1] + time.split(":")[2]
+    (time) => course?.code + ":" + time.split(":")[2] + time.split(":")[3]
   );
 
   try {

--- a/src/controllers/timetable/removeSection.ts
+++ b/src/controllers/timetable/removeSection.ts
@@ -162,7 +162,7 @@ export const removeSection = async (req: Request, res: Response) => {
   }
 
   const classTimings = section.roomTime.map((time) => {
-    return time.split(":")[1] + time.split(":")[2];
+    return time.split(":")[2] + time.split(":")[3];
   });
 
   timetable.timings = timetable.timings.filter((time) => {

--- a/src/entity/Section.ts
+++ b/src/entity/Section.ts
@@ -43,7 +43,7 @@ export class Section {
   @Column({ type: "varchar", length: 100, array: true })
   instructors!: string[];
 
-  @Column({ name: "room_time", type: "varchar", length: 20, array: true })
+  @Column({ name: "room_time", type: "varchar", length: 51, array: true })
   roomTime!: string[];
 
   @CreateDateColumn({

--- a/src/ingestJSON.ts
+++ b/src/ingestJSON.ts
@@ -262,7 +262,7 @@ export const ingestJSON = async (
             for (let k = 0; k < scheduleObjs[j].days.length; k++) {
               for (let l = 0; l < scheduleObjs[j].hours.length; l++) {
                 roomTimes.push(
-                  `${scheduleObjs[j].room}:${scheduleObjs[j].days[k]}:${scheduleObjs[j].hours[l]}`
+                  `${courseValues[i].code}:${scheduleObjs[j].room}:${scheduleObjs[j].days[k]}:${scheduleObjs[j].hours[l]}`
                 );
               }
             }

--- a/src/utils/checkForClashes.ts
+++ b/src/utils/checkForClashes.ts
@@ -17,7 +17,7 @@ export const checkForClassHoursClash = (
   }
 
   const newTimes = newRoomTimes.map((roomTime) => {
-    const [_, day, hour] = roomTime.split(":");
+    const [_, __, day, hour] = roomTime.split(":");
     return day + hour;
   });
 


### PR DESCRIPTION
Before this commit, a section in a timetable would have no way to know which course it belonged to except for the course id. This works for a backend, but for a frontend, for example when rendering the boxes in the grid, to associate it with the right course details, you'd need to do an extra filter, or rewrite how you fetch all courses.

BREAKING CHANGE: roomTimes now have the course code at the beginning