### PR TITLE
Add type of exam to examTimes to allow categories

### DIFF
--- a/src/controllers/timetable/addSection.ts
+++ b/src/controllers/timetable/addSection.ts
@@ -221,10 +221,10 @@ export const addSection = async (req: Request, res: Response) => {
                 ...timetable.examTimes,
                 `${
                   course.code
-                }|${course.midsemStartTime.toISOString()}|${course.midsemEndTime.toISOString()}`,
+                }|MIDSEM|${course.midsemStartTime.toISOString()}|${course.midsemEndTime.toISOString()}`,
                 `${
                   course.code
-                }|${course.compreStartTime.toISOString()}|${course.compreEndTime.toISOString()}`,
+                }|COMPRE|${course.compreStartTime.toISOString()}|${course.compreEndTime.toISOString()}`,
               ],
             })
             .where("timetable.id = :id", { id: timetable.id })

--- a/src/utils/checkForClashes.ts
+++ b/src/utils/checkForClashes.ts
@@ -47,7 +47,7 @@ export const checkForExamHoursClash = (
   // key: start time, value: { courseCode, end time }
   const examTimesMap = new Map<Date, { courseCode: string; end: Date }>();
   for (const examTime of examTimes) {
-    const [course, start, end] = examTime.split("|");
+    const [course, _, start, end] = examTime.split("|");
     courseCodes.add(course);
     examTimesMap.set(new Date(start), {
       courseCode: course,


### PR DESCRIPTION
Frontend can't differentiate the two types of exams without an extra API call