### PR TITLE
Add max limit to timetable ids

### DIFF
--- a/lib/src/zodFieldTypes.ts
+++ b/lib/src/zodFieldTypes.ts
@@ -45,6 +45,9 @@ export const namedTimetableIDType = (name?: string) =>
     })
     .int({
       message: addNameToString("timetable id is an invalid id", name),
+    })
+    .max(2147483647, {
+      message: addNameToString("timetable id is an invalid id", name),
     });
 
 export const timetableIDType = namedTimetableIDType();


### PR DESCRIPTION
This is to prevent very large timetable ids from causing 500s. 

It's stored as a 32-bit signed int in DB, making overflow the problem.

(resurrection of #79 due to major changes in project structure)