### PR TITLE
Fix clash rendering logic 

### DIFF
--- a/frontend/src/components/CourseDetailsMenu.tsx
+++ b/frontend/src/components/CourseDetailsMenu.tsx
@@ -159,11 +159,10 @@ const CourseDetailsMenu = () => {
                           onClick={() => handleSectionClick(section)}
                           key={section.number}
                           disabled={
-                            section.clashing !== undefined &&
-                            !timetable.sections.find(
-                              (e) =>
-                                e.courseId === section.courseId &&
-                                e.type === section.type,
+                            section.clashing &&
+                            !(
+                              section.clashing.courseId === section.courseId &&
+                              section.clashing.sectionType === section.type
                             )
                           }
                         >
@@ -185,10 +184,9 @@ const CourseDetailsMenu = () => {
                           </div>
                         </Button>
                         {section.clashing &&
-                        !timetable.sections.find(
-                          (e) =>
-                            e.courseId === section.courseId &&
-                            e.type === section.type,
+                        !(
+                          section.clashing.courseId === section.courseId &&
+                          section.clashing.sectionType === section.type
                         ) ? (
                           <div className="absolute left-0 top-8 bg-slate-700/80 text-center w-full">
                             <span className="text-slate-100 font-bold text-md">


### PR DESCRIPTION
Fix clash rendering logic to still show external clashes even if a section of the same type and course is selected

Example of the issue:
https://cdn.discordapp.com/attachments/1091600957114155038/1400405953953665144/screen-20250731-144106.mp4?ex=688c852d&is=688b33ad&hm=09606d7c29ff76aea8d022a19dca0c1ab7a22549ece9a8ad248b242da79e50ab&

Fix:
<img width="484" height="934" alt="image" src="https://github.com/user-attachments/assets/2a22c519-1105-43d5-bd36-a85063d57ae3" />
