### PR TITLE
Fix archived timetables rendering empty

### DIFF
--- a/backend/src/controllers/course/getAllCourses.ts
+++ b/backend/src/controllers/course/getAllCourses.ts
@@ -5,10 +5,22 @@ import { validate } from "../../middleware/zodValidateRequest.js";
 import { courseRepository } from "../../repositories/courseRepository.js";
 
 const dataSchema = z.object({
-  query: z.object({
-    // This type definition for archived is not ideal, but boolean() doesn't work directly as the param is read as a string, and coercing it to boolean makes all values pass the check, rendering this check useless. Thus, this is the current solution
-    archived: z.union([z.literal("true"), z.literal("false")]).optional(),
-  }),
+  query: z
+    .object({
+      // This type definition for archived is not ideal, but boolean() doesn't work directly as the param is read as a string, and coercing it to boolean makes all values pass the check, rendering this check useless. Thus, this is the current solution
+      archived: z.union([z.literal("true"), z.literal("false")]).optional(),
+      acadYear: z.coerce.number().int().optional(),
+      semester: z.coerce.number().int().optional(),
+    })
+    .refine(
+      (query) => {
+        const hasAcadYear = query.acadYear !== undefined;
+        const hasSemester = query.semester !== undefined;
+        // one param without the other is meaningless
+        return hasAcadYear === hasSemester;
+      },
+      { message: "acadYear and semester must be passed together" },
+    ),
 });
 
 export const getAllCoursesValidator = validate(dataSchema);
@@ -17,11 +29,23 @@ export const getAllCourses = async (req: Request, res: Response) => {
   const logger = req.log;
   // note that if archived is not passed as a param, (req.query.archived as string) evaluates to the string "undefined"
   const archived: boolean = (req.query.archived as string) === "true";
+  const acadYear = req.query.acadYear as string | undefined;
+  const semester = req.query.semester as string | undefined;
 
   try {
     let courses: Course[];
 
-    if (archived) {
+    if (acadYear !== undefined && semester !== undefined) {
+      // semester-scoped fetches return the courses of that semester regardless
+      // of their archived status, so that archived timetables can be viewed
+      courses = await courseRepository
+        .createQueryBuilder("course")
+        .where("course.acadYear = :acadYear", { acadYear: Number(acadYear) })
+        .andWhere("course.semester = :semester", {
+          semester: Number(semester),
+        })
+        .getMany();
+    } else if (archived) {
       courses = await courseRepository.createQueryBuilder("course").getMany();
     } else {
       courses = await courseRepository

--- a/frontend/src/components/CenteredSpinner.tsx
+++ b/frontend/src/components/CenteredSpinner.tsx
@@ -1,0 +1,10 @@
+import Spinner from "./Spinner";
+
+// full-page loading state: centers the spinner in the content area below the navbar
+const CenteredSpinner = () => (
+  <div className="flex h-[calc(100dvh-5rem)] w-full items-center justify-center">
+    <Spinner />
+  </div>
+);
+
+export default CenteredSpinner;

--- a/frontend/src/context/context.tsx
+++ b/frontend/src/context/context.tsx
@@ -1,9 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
 import { notFound, useParams } from "@tanstack/react-router";
 import type React from "react";
 import { createContext, useContext, useEffect, useReducer } from "react";
-import Spinner from "@/components/Spinner";
+import CenteredSpinner from "@/components/CenteredSpinner";
 import useCourse from "@/data-access/hooks/useCourse";
-import useCourses from "@/data-access/hooks/useCourses";
+import { courseQueryOptions } from "@/data-access/hooks/useCourses";
 import useTimetable from "@/data-access/hooks/useTimetable";
 import useUser from "@/data-access/hooks/useUser";
 import reducer from "./reducer";
@@ -53,9 +54,19 @@ export const TimetableProvider = ({
   if (timetableId === undefined) throw notFound();
   const [state, dispatch] = useReducer(reducer, initialTimetableState);
   const { data: user, isLoading: isUserLoading } = useUser();
-  const { data: courses, isLoading: isCoursesLoading } = useCourses();
   const { data: timetable, isLoading: isTimetableLoading } =
     useTimetable(timetableId);
+  // The course list must match the semester of the timetable being viewed
+  // (archived timetables reference archived courses), so the query is gated
+  // on the timetable being loaded.
+  const { data: courses, isLoading: isCoursesLoading } = useQuery({
+    ...courseQueryOptions(
+      timetable === undefined
+        ? undefined
+        : { acadYear: timetable.acadYear, semester: timetable.semester },
+    ),
+    enabled: timetable !== undefined,
+  });
   const { data: course } = useCourse(state.currentCourseID);
 
   useEffect(() => {
@@ -93,7 +104,7 @@ export const TimetableProvider = ({
   }, []);
 
   if (isUserLoading || isCoursesLoading || isTimetableLoading) {
-    return <Spinner />;
+    return <CenteredSpinner />;
   }
 
   return (

--- a/frontend/src/data-access/hooks/useCourses.ts
+++ b/frontend/src/data-access/hooks/useCourses.ts
@@ -1,19 +1,23 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import type { courseType } from "lib";
 import type z from "zod";
 import chronoAPI from "../axios";
 
-const fetchCourses = async () => {
-  const response =
-    await chronoAPI.get<z.infer<typeof courseType>[]>("/api/course");
+type CourseFilters = {
+  acadYear: number;
+  semester: number;
+};
+
+const fetchCourses = async (filters?: CourseFilters) => {
+  const response = await chronoAPI.get<z.infer<typeof courseType>[]>(
+    "/api/course",
+    { params: filters },
+  );
   return response.data;
 };
 
-export const courseQueryOptions = queryOptions({
-  queryKey: ["courses"],
-  queryFn: () => fetchCourses(),
-});
-
-const useCourses = () => useQuery(courseQueryOptions);
-
-export default useCourses;
+export const courseQueryOptions = (filters?: CourseFilters) =>
+  queryOptions({
+    queryKey: ["courses", filters ?? null],
+    queryFn: () => fetchCourses(filters),
+  });

--- a/frontend/src/pages/EditTimetable.tsx
+++ b/frontend/src/pages/EditTimetable.tsx
@@ -20,6 +20,7 @@ import { timetableQueryOptions } from "@/data-access/hooks/useTimetable";
 import { useAddRemoveTimetableSection } from "@/data-access/hooks/useTimetableSectionAction";
 import { userQueryOptions } from "@/data-access/hooks/useUser";
 import authenticatedRoute from "../AuthenticatedRoute";
+import CenteredSpinner from "../components/CenteredSpinner";
 import NotFound from "../components/NotFound";
 import { SideMenu } from "../components/SideMenu";
 import Spinner from "../components/Spinner";
@@ -36,11 +37,23 @@ import { router } from "../main";
 const editTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,
   path: "edit/$timetableId",
-  loader: ({ context: { queryClient }, params: { timetableId } }) => {
+  loader: async ({ context: { queryClient }, params: { timetableId } }) => {
     queryClient.ensureQueryData(userQueryOptions);
-    queryClient.ensureQueryData(courseQueryOptions);
-    queryClient.ensureQueryData(timetableQueryOptions(timetableId));
+    // Courses are fetched for the semester of the timetable being edited, so
+    // the timetable has to be loaded first. Awaiting both keeps this data in
+    // the loader, so preloading warms it before navigation (see
+    // https://tanstack.com/router/v1/docs/guide/data-loading)
+    const timetable = await queryClient.ensureQueryData(
+      timetableQueryOptions(timetableId),
+    );
+    await queryClient.ensureQueryData(
+      courseQueryOptions({
+        acadYear: timetable.acadYear,
+        semester: timetable.semester,
+      }),
+    );
   },
+  pendingComponent: CenteredSpinner,
   component: () => (
     <TimetableProvider>
       <EditTimetable />

--- a/frontend/src/pages/ViewTimetable.tsx
+++ b/frontend/src/pages/ViewTimetable.tsx
@@ -19,6 +19,7 @@ import { courseQueryOptions } from "@/data-access/hooks/useCourses";
 import { timetableQueryOptions } from "@/data-access/hooks/useTimetable";
 import { userQueryOptions } from "@/data-access/hooks/useUser";
 import authenticatedRoute from "../AuthenticatedRoute";
+import CenteredSpinner from "../components/CenteredSpinner";
 import NotFound from "../components/NotFound";
 import { SideMenu } from "../components/SideMenu";
 import Spinner from "../components/Spinner";
@@ -35,11 +36,23 @@ import { toast, useToast } from "../components/ui/use-toast";
 const viewTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,
   path: "view/$timetableId",
-  loader: ({ context: { queryClient }, params: { timetableId } }) => {
+  loader: async ({ context: { queryClient }, params: { timetableId } }) => {
     queryClient.ensureQueryData(userQueryOptions);
-    queryClient.ensureQueryData(courseQueryOptions);
-    queryClient.ensureQueryData(timetableQueryOptions(timetableId));
+    // Courses are fetched for the semester of the timetable being viewed, so
+    // the timetable has to be loaded first. Awaiting both keeps this data in
+    // the loader, so preloading warms it before navigation (see
+    // https://tanstack.com/router/v1/docs/guide/data-loading)
+    const timetable = await queryClient.ensureQueryData(
+      timetableQueryOptions(timetableId),
+    );
+    await queryClient.ensureQueryData(
+      courseQueryOptions({
+        acadYear: timetable.acadYear,
+        semester: timetable.semester,
+      }),
+    );
   },
+  pendingComponent: CenteredSpinner,
   component: () => (
     <TimetableProvider>
       <ViewTimetable />


### PR DESCRIPTION
Archived timetables rendered empty: the course list only returns non-archived courses by default, but an archived timetable's sections point at archived courses, so the frontend's section→course join found nothing (and threw on the unguarded lookup). Draft/published timetables only reference current courses, which is why they were fine.

`/api/course` now accepts `acadYear`+`semester` and returns that semester's courses regardless of archived status, and the frontend fetches courses for the semester of the timetable being viewed. Used the timetable's own semester rather than the existing `archived=true` flag because that returns every course ever ingested, and course codes are no longer unique in the list (breaks CDC matching).

Verified with a seeded archived course + timetable: default `/api/course` omits it, `/api/course?acadYear=2024&semester=2` returns it, `?acadYear=2024` alone 400s, and the default behavior is unchanged.
