### PR TITLE
Fix private and draft timetables leaking to other users

### DIFF
--- a/backend/src/controllers/user/getUserDetails.ts
+++ b/backend/src/controllers/user/getUserDetails.ts
@@ -22,12 +22,15 @@ export const getUserDetails = async (req: Request, res: Response) => {
   try {
     user = await userRepository
       .createQueryBuilder("user")
+      // the join's parameter must not be named :id — query builder params
+      // are global, and the where clause below would overwrite this binding
+      // and silently disable the private/draft filter
       .leftJoin(
         "user.timetables",
         "timetable",
-        "(user.id <> :id and timetable.private = :private and timetable.draft = :draft) or (user.id = :id)",
+        "(user.id <> :sessionId and timetable.private = :private and timetable.draft = :draft) or (user.id = :sessionId)",
         {
-          id: req.session?.id,
+          sessionId: req.session?.id,
           draft: false,
           private: false,
         },
@@ -50,7 +53,7 @@ export const getUserDetails = async (req: Request, res: Response) => {
       .getOne();
   } catch (err: any) {
     logger.error("Error while querying for user: ", err.message);
-    res.status(500).json({ message: "Internal Server Error" });
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 
   if (!user) {

--- a/backend/src/routers/userRouter.ts
+++ b/backend/src/routers/userRouter.ts
@@ -21,11 +21,6 @@ userRouter.post(
   createAnnouncement,
 );
 userRouter.get("/announcements", authenticate, getAllAnnouncements);
-userRouter.get(
-  "/{.:id}",
-  authenticate,
-  getUserDetailsValidator,
-  getUserDetails,
-);
+userRouter.get("/{:id}", authenticate, getUserDetailsValidator, getUserDetails);
 
 export default userRouter;


### PR DESCRIPTION
A user's profile endpoint listed their private and draft timetables to any logged-in user. `getUserDetails` reused the `:id` parameter name for the session id in the join condition and the profile owner's id in the where clause — query builder params are global and the later binding wins, so the private/draft join filter silently did nothing.

Also fixes the `/{.:id}` route pattern, which only matched dot-prefixed URLs (`/user/.<uuid>`) and 404'd normal profile URLs.

(Dropped the timetable-fetch authorization change per review — private means unlisted, not hidden from link-holders.)

Verified with two seeded users: others' profiles now show only public non-draft timetables, your own profile shows everything, and direct timetable links still work for anyone.
