### PR TITLE
Fix expired sessions returning 500 instead of 401

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -58,6 +58,14 @@ export const authenticate = async (
     req.session = parsedSession.data;
     return next();
   } catch (error) {
+    // jwt.verify throws JsonWebTokenError (and its TokenExpiredError
+    // subclass) for expired or otherwise invalid sessions
+    if (error instanceof jwt.JsonWebTokenError) {
+      return res.status(401).json({
+        message: "unauthorized",
+        error: "invalid user session",
+      });
+    }
     return res.status(500).json(JSON.stringify(error));
   }
 };


### PR DESCRIPTION
Expired sessions returned 500 with a stringified `TokenExpiredError` instead of 401. Session expiry is routine, and the frontend's login redirect keys off 401, so lapsed sessions dead-ended with a generic error instead of redirecting.

JWT failures (`JsonWebTokenError`, which includes expiry) now map to 401; anything else still 500s.

Verified with a minted expired session cookie: 500 → 401, valid and missing cookies behave as before.
