### PR TITLE
Fix broken filters in getPublicTimetables

### DIFF
--- a/backend/src/controllers/timetable/getPublicTimetables.ts
+++ b/backend/src/controllers/timetable/getPublicTimetables.ts
@@ -3,9 +3,7 @@ import { z } from "zod";
 import {
   type degreeList,
   isAValidDegreeCombination,
-  namedCollegeYearType,
   namedDegreeZodList,
-  namedSemesterType,
 } from "../../../../lib/src/index.js";
 import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
@@ -15,16 +13,22 @@ import sqids from "../../utils/sqids.js";
 
 const dataSchema = z.object({
   query: z.object({
-    year: namedCollegeYearType("search").optional(),
-    sem: namedSemesterType("search").optional(),
-    branch: namedDegreeZodList("search branch")
-      .min(1, {
-        error:
-          "search branch must be a non-empty array of valid degree strings",
-      })
-      .max(2, {
-        error: "search branch may not contain more than two elements",
-      })
+    // query params arrive as strings, so they have to be coerced
+    year: z.coerce.number().int().gte(1).lte(6).optional(),
+    sem: z.coerce.number().int().gte(1).lte(2).optional(),
+    branch: z
+      .preprocess(
+        // ?branch=A7 parses as a bare string, not a one-element array
+        (value) => (Array.isArray(value) ? value : [value]),
+        namedDegreeZodList("search branch")
+          .min(1, {
+            error:
+              "search branch must be a non-empty array of valid degree strings",
+          })
+          .max(2, {
+            error: "search branch may not contain more than two elements",
+          }),
+      )
       .optional(),
     // This type definition for archived is not ideal, but boolean() doesn't work directly as the param is read as a string, and coercing it to boolean makes all values pass the check, rendering this check useless. Thus, this is the current solution
     archived: z.union([z.literal("true"), z.literal("false")]).optional(),
@@ -53,7 +57,14 @@ export const getPublicTimetables = async (req: Request, res: Response) => {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const branch: degreeList = req.query.branch as degreeList;
+    // the validator doesn't write parsed values back, so normalize here too:
+    // a single ?branch=A7 arrives as a bare string instead of an array
+    const branch: degreeList | undefined =
+      req.query.branch === undefined
+        ? undefined
+        : ((Array.isArray(req.query.branch)
+            ? req.query.branch
+            : [req.query.branch]) as degreeList);
     const year: number = Number.parseInt(req.query.year as string, 10);
     const sem: number = Number.parseInt(req.query.sem as string, 10);
     // note that if archived is not passed as a param, (req.query.archived as string) evaluates to the string "undefined"
@@ -84,9 +95,12 @@ export const getPublicTimetables = async (req: Request, res: Response) => {
             "Branch may only have one valid BE degree and one valid MSc degee",
         });
       }
-      queryBuilder = queryBuilder.andWhere("timetable.degrees = :branch", {
-        branch,
-      });
+      // match the degrees array in either order (stored order depends on how
+      // the user picked their degrees)
+      queryBuilder = queryBuilder.andWhere(
+        "timetable.degrees @> :branch AND timetable.degrees <@ :branch",
+        { branch },
+      );
     }
 
     if (year) {
@@ -119,6 +133,7 @@ export const getPublicTimetables = async (req: Request, res: Response) => {
       return res.status(500).json({ message: "Internal Server Error" });
     }
   } catch (err: any) {
-    return err;
+    logger.error(err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 };


### PR DESCRIPTION
Every filter on `getPublicTimetables` was broken, so only the unfiltered dump worked:

- `?year=`/`?sem=` always 400'd — validated with `z.int()`, but query params are strings.
- A single `?branch=A7` always 400'd — it parses as a bare string, not an array.
- Branch matching used Postgres array equality, which is order-sensitive, so a timetable stored as `[B3, A1]` was invisible to a search for `[A1, B3]`.
- The outer catch did `return err` without sending a response, hanging the request.

Coerce the numbers in the schema, normalize branch to an array, match degrees by mutual containment (`@>` + `<@`), and return a real 500 from the outer catch.

Verified against seeded data: `?year=4` filters correctly, both branch orders return the same timetable, single branch works, `?year=9` still 400s. Note nothing in the current frontend calls this endpoint yet, so this is low-risk.
