### PR TITLE
Fix /course/update rejecting courses without exams

### DIFF
--- a/lib/src/zodEntityTypes.ts
+++ b/lib/src/zodEntityTypes.ts
@@ -20,18 +20,20 @@ export const namedCourseType = (name?: string) =>
     id: namedUUIDType(addNameToString("course", name)),
     code: namedNonEmptyStringType(addNameToString("course code", name)),
     name: namedNonEmptyStringType(addNameToString("course name", name)),
+    // exam timings are nullable in the database (courses without exams,
+    // e.g. labs/projects, have NULLs), so they must be nullable here too
     midsemStartTime: namedISOTimestampType(
       addNameToString("course midsemStartTime", name),
-    ),
+    ).nullable(),
     midsemEndTime: namedISOTimestampType(
       addNameToString("course midsemEndTime", name),
-    ),
+    ).nullable(),
     compreStartTime: namedISOTimestampType(
       addNameToString("course compreStartTime", name),
-    ),
+    ).nullable(),
     compreEndTime: namedISOTimestampType(
       addNameToString("course compreEndTime", name),
-    ),
+    ).nullable(),
     archived: namedBooleanType(addNameToString("course archived", name)),
     acadYear: namedYearType(addNameToString("course acadYear", name)),
     semester: namedSemesterType(addNameToString("course", name)),


### PR DESCRIPTION
`/course/update` could never update courses that have no exams (labs, projects — ~28% of the catalog). The zod schema required all four exam timestamps to be non-empty ISO strings, but the DB columns are nullable and ingestion writes NULL for exam-less courses, so their update payloads always 400'd.

The schema was just out of sync with reality: the API already returns `null` in these fields, and the frontend already treats them as `string | null`. Made the four fields nullable.

Verified: POSTing an exam-less course went from 400 (ZodError on all four fields) to 200, and all three workspace builds pass with the widened type.
