### PR TITLE
Fix addSection committing writes after a failed query

### DIFF
--- a/backend/src/controllers/timetable/addSection.ts
+++ b/backend/src/controllers/timetable/addSection.ts
@@ -158,7 +158,7 @@ export const addSection = async (req: Request, res: Response) => {
       err.message,
     );
 
-    res.status(500).json({ message: "Internal Server Error" });
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 
   let sameCourseSectionsCount = 0;
@@ -177,7 +177,7 @@ export const addSection = async (req: Request, res: Response) => {
       err.message,
     );
 
-    res.status(500).json({ message: "Internal Server Error" });
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 
   if (sameCourseSectionsCount > 0) {


### PR DESCRIPTION
Two catch blocks in `addSection` sent a 500 but didn't return, so execution continued into the write path with empty query results — skipping the duplicate-section-type guard and computing warnings from nothing — then committed the section anyway and tried to send a second response. Net effect on a transient DB error: client sees 500, but the section was actually added.

Added the missing returns. Verified add/remove roundtrip still 200s and the clash guard still 400s with the right message.
