### PR TITLE
Fix double response in deleteTimetable error path

### DIFF
--- a/backend/src/controllers/timetable/deleteTimetable.ts
+++ b/backend/src/controllers/timetable/deleteTimetable.ts
@@ -70,7 +70,7 @@ export const deleteTimetable = async (req: Request, res: Response) => {
   } catch (err: any) {
     logger.error("Error while deleting timetable: ", err.message);
 
-    res.status(500).json({ message: "Internal Server Error" });
+    return res.status(500).json({ message: "Internal Server Error" });
   }
   return res.json({ message: "timetable deleted" });
 };


### PR DESCRIPTION
The catch around the actual DELETE in `deleteTimetable` sent a 500 but didn't return, so a failed delete fell through and also tried to send the 200 success response (double-send, which then leaks a stack via the Express error handler).

Added the return. Verified the ownership guard still 403s and a create/delete roundtrip still 200s.
