### PR TITLE
Fix announcements not being ordered newest-first

### DIFF
--- a/backend/src/controllers/user/getAnnouncements.ts
+++ b/backend/src/controllers/user/getAnnouncements.ts
@@ -6,6 +6,7 @@ export const getAllAnnouncements = async (req: Request, res: Response) => {
   try {
     const announcements = await announcementRepository
       .createQueryBuilder("announcement")
+      .orderBy("announcement.createdAt", "DESC")
       .getMany();
 
     return res.status(200).json(announcements);


### PR DESCRIPTION
`getAllAnnouncements` had no `ORDER BY`, so Postgres returned rows in whatever order it felt like — a new announcement could show up anywhere in the list.

Now ordered by `createdAt DESC`. Verified newest-first with two seeded announcements.
