### PR TITLE
Fix year-2 students being blocked from registration

### DIFF
--- a/frontend/src/pages/GetDegrees.tsx
+++ b/frontend/src/pages/GetDegrees.tsx
@@ -56,7 +56,7 @@ function GetDegrees() {
 
   const handleSubmit = async () => {
     if (firstDegree) {
-      if (firstDegree?.includes("B") && year >= 2 && secondDegree === null) {
+      if (firstDegree?.includes("B") && year >= 3 && secondDegree === null) {
         toast({
           title: "Select your second degree!",
           variant: "destructive",
@@ -64,7 +64,7 @@ function GetDegrees() {
         return;
       }
       const degrees =
-        firstDegree?.includes("B") && year >= 2 && secondDegree !== "A0"
+        firstDegree?.includes("B") && year >= 3 && secondDegree !== "A0"
           ? [firstDegree, secondDegree]
           : [firstDegree];
       createUser(


### PR DESCRIPTION
The submit handler required M.Sc. students in `year >= 2` to pick a B.E. dual, but the dual-degree dropdown only rendered for `year > 2`, so year-2 students were hard-blocked from registering with a "Select your second degree!" toast they couldn't do anything about.

Per review: 2-1 students haven't declared their dual yet (that happens after 2-1 registration), so the dual question shouldn't apply in year 2 at all. Aligned the submit guard with the dropdown (`year >= 3`): year-2 students now register as single-degree, and can add their dual later from Edit Profile, which already supports a second degree.

(A one-time prompt in 3-1 nudging M.Sc. students to set their dual would be a separate feature.)
