### PR TITLE
Fix first edit attempt bouncing back to view page

### DIFF
--- a/frontend/src/data-access/hooks/useEditTimetable.ts
+++ b/frontend/src/data-access/hooks/useEditTimetable.ts
@@ -19,8 +19,12 @@ const useEditTimetable = () => {
     mutationFn: (data: EditTimetableParams) => {
       return chronoAPI.post(`/api/timetable/${data.id}/edit`, data.body);
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["user"] });
+      // the edited timetable's own cache entry is stale too (e.g. draft flag
+      // flipped by the edit button), otherwise the edit page bounces back
+      // with a spurious "non-draft timetables cannot be edited" error
+      queryClient.invalidateQueries({ queryKey: ["timetable", variables.id] });
     },
     onError: (e) => toastHandler(e, toast),
   });


### PR DESCRIPTION
Every first click on Edit for a non-draft timetable bounced back to /view with a spurious "non-draft timetables cannot be edited" error; the second click worked.

The edit mutation flips the timetable to draft server-side but only invalidated `["user"]`. The edit page's loader then served the cached timetable (still non-draft) via `ensureQueryData`, and the page guard bounced. The background refetch fixed the cache eventually, hence the second attempt working.

Now also invalidates `["timetable", id]`.
