### PR TITLE
Fix midsem-only exam clash warning never appearing

### DIFF
--- a/frontend/src/components/SideMenu.tsx
+++ b/frontend/src/components/SideMenu.tsx
@@ -64,7 +64,7 @@ export function SideMenu({
         const clashes = timetable.examTimes.filter((x) => {
           if (x.split("|")[0] === e.code) return false;
           return x.includes(
-            `${withClash.midsemStartTime}|${withClash.midsemStartTime}`,
+            `${withClash.midsemStartTime}|${withClash.midsemEndTime}`,
           );
         });
         withClash.clashing = clashes.length === 0 ? null : clashes;


### PR DESCRIPTION
The midsem-only exam clash check searched exam entries for `start|start` (start time twice), but entries are stored as `CODE|MIDSEM|start|end`, so it could never match and the "Clashing with X's midsem" badge never showed for courses with a midsem but no compre.

Fixed to `start|end`, matching the other branches. Verified against seeded exam entries: 0 matches before, 1 after.
