### PR TITLE
Fix Course entity typing nullable exam columns as non-null

### DIFF
--- a/backend/src/controllers/timetable/updateChangedTimetable.ts
+++ b/backend/src/controllers/timetable/updateChangedTimetable.ts
@@ -103,10 +103,14 @@ export const updateChangedTimetable = async (req: Request, res: Response) => {
         // This is needed because the course exam dates are not from DB,
         // but are from the JSON body of the request.
         // A similar procedure is used during ingestion as well.
-        course.compreStartTime = new Date(course.compreStartTime);
-        course.compreEndTime = new Date(course.compreEndTime);
-        course.midsemStartTime = new Date(course.midsemStartTime);
-        course.midsemEndTime = new Date(course.midsemEndTime);
+        if (course.compreStartTime !== null && course.compreEndTime !== null) {
+          course.compreStartTime = new Date(course.compreStartTime);
+          course.compreEndTime = new Date(course.compreEndTime);
+        }
+        if (course.midsemStartTime !== null && course.midsemEndTime !== null) {
+          course.midsemStartTime = new Date(course.midsemStartTime);
+          course.midsemEndTime = new Date(course.midsemEndTime);
+        }
 
         // Check if the new timings clash with any other timings of other courses
         if (checkForExamHoursClash(timetable, course).clash) {

--- a/backend/src/entity/entities.ts
+++ b/backend/src/entity/entities.ts
@@ -153,16 +153,16 @@ export class Course {
   sections!: Section[];
 
   @Column({ name: "midsem_start_time", type: "timestamptz", nullable: true })
-  midsemStartTime!: Date;
+  midsemStartTime!: Date | null;
 
   @Column({ name: "midsem_end_time", type: "timestamptz", nullable: true })
-  midsemEndTime!: Date;
+  midsemEndTime!: Date | null;
 
   @Column({ name: "compre_start_time", type: "timestamptz", nullable: true })
-  compreStartTime!: Date;
+  compreStartTime!: Date | null;
 
   @Column({ name: "compre_end_time", type: "timestamptz", nullable: true })
-  compreEndTime!: Date;
+  compreEndTime!: Date | null;
 
   @Column({ type: "boolean", default: false })
   archived!: boolean;


### PR DESCRIPTION
The four exam columns are nullable in the DB and ingestion writes NULL for exam-less courses, but the `Course` entity declared them as non-null `Date` — so TypeScript could never catch code that assumes exams always exist. Same mismatch as the zod schema in #265, one layer down.

Declaring them `Date | null` immediately surfaced a real bug at compile time: `updateChangedTimetable` converted exam times with `new Date(course.midsemStartTime)` unguarded, which for an exam-less course (accepted by the schema since #265) would have produced epoch dates (`new Date(null)`) and made the clash check treat phantom exams as real. The conversion is now guarded on non-null, matching the pattern used everywhere else these fields are read.

Verified: `tsc` clean; POST `/course/update` for an exam-less seeded course returns 200 and the affected timetable is untouched (with #265's schema applied).
