### PR TITLE
Fix CI not re-triggering on pushes to ready-marked PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,14 @@ name: Build code
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
   push:
     branches: [ master ]
   merge_group:
 
 jobs:
   build:
-    if: ${{ github.event.label.name == 'ready' || github.event_name == 'push' || github.event_name == 'merge_group' }}
+    if: ${{ github.event.label.name == 'ready' || contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push' || github.event_name == 'merge_group' }}
     runs-on: self-hosted
     steps:
       - name: Checkout

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,14 +2,14 @@ name: Lint code and check formatting with BiomeJS
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
   push:
     branches: [ master ]
   merge_group:
 
 jobs:
   linting:
-    if: ${{ github.event.label.name == 'ready' || github.event_name == 'push' || github.event_name == 'merge_group' }}
+    if: ${{ github.event.label.name == 'ready' || contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push' || github.event_name == 'merge_group' }}
     runs-on: self-hosted
     steps:
       - name: Checkout


### PR DESCRIPTION
CI only triggered on the `labeled` event, so once a PR was marked `ready`, pushing new commits to it never re-ran the checks — reviews could go green on stale code.

Adds `synchronize` to the trigger types and extends the job condition to run when the PR already has the `ready` label (on `synchronize`, the label isn't in the event payload's `label` field, so it checks the PR's label list instead).

Self-verifying: after labeling this PR `ready`, I'll push an empty commit — CI should run again without re-labeling.
