### PR TITLE
Clean up backend internals

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -51,9 +51,9 @@ app.use("/timetable", timetableRouter);
 app.disable("x-powered-by");
 
 // Error handling
-app.use((err: any, _req: Request, res: Response, _: NextFunction) => {
-  console.log(err);
-  res.status(err.status || 500).send(err.stack);
+app.use((err: any, req: Request, res: Response, _: NextFunction) => {
+  req.log.error(err);
+  res.status(err.status || 500).json({ message: "Internal Server Error" });
 });
 
 export default app;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,7 +1,6 @@
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import cors from "cors";
-import "dotenv/config";
 import express, {
   type NextFunction,
   type Request,

--- a/backend/src/config/schema.ts
+++ b/backend/src/config/schema.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
  */
 export const serverSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]),
-  PGUSER: z.string().min(1),
   POSTGRES_USER: z.string().min(1),
   POSTGRES_PASSWORD: z.string().min(1),
   POSTGRES_DB: z.string().min(1),
@@ -20,14 +19,10 @@ export const serverSchema = z.object({
     .string()
     .regex(/^\d+-[a-z0-9]+\.apps\.googleusercontent\.com$/),
   GOOGLE_CLIENT_SECRET: z.string().min(1),
-  FRONTEND_DEV_PORT: z.coerce.number().prefault(5173),
   JWT_PRIVATE_KEY: z.string().min(1),
   JWT_PUBLIC_KEY: z.string().min(1),
-  NGINX_PORT: z.coerce.number().prefault(80),
   SQIDS_ALPHABET: z.string().min(62),
   SESSION_MAX_AGE_MS: z.coerce.number().prefault(86400000),
-  VITE_FRONTEND_URL: z.url().min(1),
-  VITE_CMS_EXTENSION_ID: z.string().min(1),
   CHRONO_SECRET: z.string().min(1),
   DB_LONG_RUNNING_QUERY_MS: z.coerce.number().prefault(2000),
   LOG_MODE: z.enum(["development", "production"]).optional(),

--- a/backend/src/config/server.ts
+++ b/backend/src/config/server.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import type { z } from "zod";
 // @ts-check
 import { serverSchema } from "./schema.js";

--- a/backend/src/controllers/course/getAllCourses.ts
+++ b/backend/src/controllers/course/getAllCourses.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import type { Course } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { courseRepository } from "../../repositories/courseRepository.js";
+import { courseRepository } from "../../repositories/index.js";
 
 const dataSchema = z.object({
   query: z

--- a/backend/src/controllers/course/getCourseById.ts
+++ b/backend/src/controllers/course/getCourseById.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
+import { namedUUIDType } from "lib";
 import { z } from "zod";
-import { namedUUIDType } from "../../../../lib/src/index.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { courseRepository } from "../../repositories/courseRepository.js";
 

--- a/backend/src/controllers/course/getCourseById.ts
+++ b/backend/src/controllers/course/getCourseById.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { namedUUIDType } from "lib";
 import { z } from "zod";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { courseRepository } from "../../repositories/courseRepository.js";
+import { courseRepository } from "../../repositories/index.js";
 
 const dataSchema = z.object({
   params: z.object({

--- a/backend/src/controllers/timetable/addSection.ts
+++ b/backend/src/controllers/timetable/addSection.ts
@@ -1,10 +1,6 @@
 import type { Request, Response } from "express";
+import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
 import { z } from "zod";
-import {
-  namedUUIDType,
-  type sectionTypeList,
-  timetableIDType,
-} from "../../../../lib/src/index.js";
 import {
   type Course,
   type Section,

--- a/backend/src/controllers/timetable/addSection.ts
+++ b/backend/src/controllers/timetable/addSection.ts
@@ -8,10 +8,12 @@ import {
   type User,
 } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { courseRepository } from "../../repositories/courseRepository.js";
-import { sectionRepository } from "../../repositories/sectionRepository.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  courseRepository,
+  sectionRepository,
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import {
   checkForClassHoursClash,
   checkForExamHoursClash,

--- a/backend/src/controllers/timetable/copyTimetable.ts
+++ b/backend/src/controllers/timetable/copyTimetable.ts
@@ -3,8 +3,10 @@ import { type degreeEnum, timetableIDType } from "lib";
 import { z } from "zod";
 import { type Section, Timetable, type User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import timetableJSON from "../../timetable.json" with { type: "json" };
 import sqids, { validSqid } from "../../utils/sqids.js";
 

--- a/backend/src/controllers/timetable/copyTimetable.ts
+++ b/backend/src/controllers/timetable/copyTimetable.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
+import { type degreeEnum, timetableIDType } from "lib";
 import { z } from "zod";
-import { type degreeEnum, timetableIDType } from "../../../../lib/src/index.js";
 import { type Section, Timetable, type User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { timetableRepository } from "../../repositories/timetableRepository.js";

--- a/backend/src/controllers/timetable/createTimetable.ts
+++ b/backend/src/controllers/timetable/createTimetable.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import type { degreeEnum } from "../../../../lib/src/index.js";
+import type { degreeEnum } from "lib";
 import { type Section, Timetable, type User } from "../../entity/entities.js";
 import { timetableRepository } from "../../repositories/timetableRepository.js";
 import { userRepository } from "../../repositories/userRepository.js";

--- a/backend/src/controllers/timetable/createTimetable.ts
+++ b/backend/src/controllers/timetable/createTimetable.ts
@@ -1,8 +1,10 @@
 import type { Request, Response } from "express";
 import type { degreeEnum } from "lib";
 import { type Section, Timetable, type User } from "../../entity/entities.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import timetableJSON from "../../timetable.json" with { type: "json" };
 import sqids from "../../utils/sqids.js";
 

--- a/backend/src/controllers/timetable/deleteTimetable.ts
+++ b/backend/src/controllers/timetable/deleteTimetable.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import type { Request, Response } from "express";
+import { timetableIDType } from "lib";
 import { z } from "zod";
-import { timetableIDType } from "../../../../lib/src/index.js";
 import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { timetableRepository } from "../../repositories/timetableRepository.js";

--- a/backend/src/controllers/timetable/deleteTimetable.ts
+++ b/backend/src/controllers/timetable/deleteTimetable.ts
@@ -4,8 +4,10 @@ import { timetableIDType } from "lib";
 import { z } from "zod";
 import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import sqids, { validSqid } from "../../utils/sqids.js";
 
 const dataSchema = z.object({

--- a/backend/src/controllers/timetable/deleteTimetable.ts
+++ b/backend/src/controllers/timetable/deleteTimetable.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import type { Request, Response } from "express";
 import { timetableIDType } from "lib";
 import { z } from "zod";

--- a/backend/src/controllers/timetable/editTimetableMetadata.ts
+++ b/backend/src/controllers/timetable/editTimetableMetadata.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import type { Request, Response } from "express";
 import {
   namedBooleanType,

--- a/backend/src/controllers/timetable/editTimetableMetadata.ts
+++ b/backend/src/controllers/timetable/editTimetableMetadata.ts
@@ -1,11 +1,11 @@
 import "dotenv/config";
 import type { Request, Response } from "express";
-import { z } from "zod";
 import {
   namedBooleanType,
   namedNonEmptyStringType,
   timetableIDType,
-} from "../../../../lib/src/index.js";
+} from "lib";
+import { z } from "zod";
 import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { timetableRepository } from "../../repositories/timetableRepository.js";

--- a/backend/src/controllers/timetable/editTimetableMetadata.ts
+++ b/backend/src/controllers/timetable/editTimetableMetadata.ts
@@ -8,8 +8,10 @@ import {
 import { z } from "zod";
 import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import sqids, { validSqid } from "../../utils/sqids.js";
 
 const dataSchema = z.object({

--- a/backend/src/controllers/timetable/getTimetableById.ts
+++ b/backend/src/controllers/timetable/getTimetableById.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
+import { timetableIDType } from "lib";
 import { z } from "zod";
-import { timetableIDType } from "../../../../lib/src/index.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { timetableRepository } from "../../repositories/timetableRepository.js";
 import sqids, { validSqid } from "../../utils/sqids.js";

--- a/backend/src/controllers/timetable/getTimetableById.ts
+++ b/backend/src/controllers/timetable/getTimetableById.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { timetableIDType } from "lib";
 import { z } from "zod";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
+import { timetableRepository } from "../../repositories/index.js";
 import sqids, { validSqid } from "../../utils/sqids.js";
 
 const dataSchema = z.object({

--- a/backend/src/controllers/timetable/removeSection.ts
+++ b/backend/src/controllers/timetable/removeSection.ts
@@ -1,10 +1,6 @@
 import type { Request, Response } from "express";
+import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
 import { z } from "zod";
-import {
-  namedUUIDType,
-  type sectionTypeList,
-  timetableIDType,
-} from "../../../../lib/src/index.js";
 import type {
   Course,
   Section,

--- a/backend/src/controllers/timetable/removeSection.ts
+++ b/backend/src/controllers/timetable/removeSection.ts
@@ -8,10 +8,12 @@ import type {
   User,
 } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { courseRepository } from "../../repositories/courseRepository.js";
-import { sectionRepository } from "../../repositories/sectionRepository.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  courseRepository,
+  sectionRepository,
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import sqids, { validSqid } from "../../utils/sqids.js";
 import { updateSectionWarnings } from "../../utils/updateWarnings.js";
 

--- a/backend/src/controllers/timetable/swapSections.ts
+++ b/backend/src/controllers/timetable/swapSections.ts
@@ -1,10 +1,6 @@
 import type { Request, Response } from "express";
+import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
 import { z } from "zod";
-import {
-  namedUUIDType,
-  type sectionTypeList,
-  timetableIDType,
-} from "../../../../lib/src/index.js";
 import {
   type Course,
   type Section,

--- a/backend/src/controllers/timetable/swapSections.ts
+++ b/backend/src/controllers/timetable/swapSections.ts
@@ -8,10 +8,12 @@ import {
   type User,
 } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { courseRepository } from "../../repositories/courseRepository.js";
-import { sectionRepository } from "../../repositories/sectionRepository.js";
-import { timetableRepository } from "../../repositories/timetableRepository.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import {
+  courseRepository,
+  sectionRepository,
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
 import {
   checkForClassHoursClash,
   checkForExamHoursClash,

--- a/backend/src/controllers/timetable/updateChangedTimetable.ts
+++ b/backend/src/controllers/timetable/updateChangedTimetable.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from "express";
-import { z } from "zod";
 import {
   courseWithSectionsType,
   namedNonEmptyStringType,
   type sectionTypeList,
-} from "../../../../lib/src/index.js";
+} from "lib";
+import { z } from "zod";
 import { env } from "../../config/server.js";
 import { AppDataSource } from "../../db.js";
 import { Course, Section, Timetable } from "../../entity/entities.js";

--- a/backend/src/controllers/user/auth.ts
+++ b/backend/src/controllers/user/auth.ts
@@ -9,7 +9,7 @@ import * as client from "openid-client";
 import { getConfig } from "../../config/authClient.js";
 import { env } from "../../config/server.js";
 import { User } from "../../entity/entities.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import { userRepository } from "../../repositories/index.js";
 import timetableJSON from "../../timetable.json" with { type: "json" };
 import {
   type FinishedUserSession,

--- a/backend/src/controllers/user/auth.ts
+++ b/backend/src/controllers/user/auth.ts
@@ -1,11 +1,11 @@
 import type { Request, Response } from "express";
-import * as client from "openid-client";
 import {
   type degreeList,
   getBatchFromEmail,
   isAValidDegreeCombination,
   namedDegreeZodList,
-} from "../../../../lib/src/index.js";
+} from "lib";
+import * as client from "openid-client";
 import { getConfig } from "../../config/authClient.js";
 import { env } from "../../config/server.js";
 import { User } from "../../entity/entities.js";

--- a/backend/src/controllers/user/createAnnouncement.ts
+++ b/backend/src/controllers/user/createAnnouncement.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
+import { announcementType, namedNonEmptyStringType } from "lib";
 import { z } from "zod";
-import {
-  announcementType,
-  namedNonEmptyStringType,
-} from "../../../../lib/src/index.js";
 import { env } from "../../config/server.js";
 import { Announcement } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";

--- a/backend/src/controllers/user/createAnnouncement.ts
+++ b/backend/src/controllers/user/createAnnouncement.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { env } from "../../config/server.js";
 import { Announcement } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { announcementRepository } from "../../repositories/announcementRepository.js";
+import { announcementRepository } from "../../repositories/index.js";
 
 const announcementSchema = z.object({
   body: announcementType.extend({

--- a/backend/src/controllers/user/editUser.ts
+++ b/backend/src/controllers/user/editUser.ts
@@ -6,7 +6,7 @@ import {
 } from "lib";
 import { z } from "zod";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import { userRepository } from "../../repositories/index.js";
 
 const dataSchema = z.object({
   body: z.object({

--- a/backend/src/controllers/user/editUser.ts
+++ b/backend/src/controllers/user/editUser.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from "express";
-import { z } from "zod";
 import {
   type degreeList,
   isAValidDegreeCombination,
   namedDegreeZodList,
-} from "../../../../lib/src/index.js";
+} from "lib";
+import { z } from "zod";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { userRepository } from "../../repositories/userRepository.js";
 

--- a/backend/src/controllers/user/getAnnouncements.ts
+++ b/backend/src/controllers/user/getAnnouncements.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { announcementRepository } from "../../repositories/announcementRepository.js";
+import { announcementRepository } from "../../repositories/index.js";
 
 export const getAllAnnouncements = async (req: Request, res: Response) => {
   const logger = req.log;

--- a/backend/src/controllers/user/getUserDetails.ts
+++ b/backend/src/controllers/user/getUserDetails.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
+import { namedUUIDType } from "lib";
 import { z } from "zod";
-import { namedUUIDType } from "../../../../lib/src/index.js";
 import type { User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { userRepository } from "../../repositories/userRepository.js";

--- a/backend/src/controllers/user/getUserDetails.ts
+++ b/backend/src/controllers/user/getUserDetails.ts
@@ -3,7 +3,7 @@ import { namedUUIDType } from "lib";
 import { z } from "zod";
 import type { User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import { userRepository } from "../../repositories/userRepository.js";
+import { userRepository } from "../../repositories/index.js";
 import sqids from "../../utils/sqids.js";
 
 const dataSchema = z.object({

--- a/backend/src/entity/entities.ts
+++ b/backend/src/entity/entities.ts
@@ -1,4 +1,10 @@
 import {
+  approvedDegreeList,
+  approvedSectionTypeList,
+  type degreeEnum,
+  type sectionTypeEnum,
+} from "lib";
+import {
   Column,
   CreateDateColumn,
   Entity,
@@ -12,12 +18,6 @@ import {
   Unique,
   UpdateDateColumn,
 } from "typeorm";
-import {
-  approvedDegreeList,
-  approvedSectionTypeList,
-  type degreeEnum,
-  type sectionTypeEnum,
-} from "../../../lib/src/index.js";
 
 @Entity()
 export class User {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,3 @@
-// import "dotenv/config";
 import app from "./app.js";
 import { env } from "./config/server.js";
 import { initializeDataSource } from "./db.js";

--- a/backend/src/ingest.ts
+++ b/backend/src/ingest.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { AppDataSource, initializeDataSource } from "./db.js";
 import { ingestJSON } from "./ingestJSON.js";
 import timetableJSON from "./timetable.json" with { type: "json" };

--- a/backend/src/ingestJSON.ts
+++ b/backend/src/ingestJSON.ts
@@ -1,5 +1,5 @@
+import type { sectionTypeEnum } from "lib";
 import type { QueryRunner } from "typeorm";
-import type { sectionTypeEnum } from "../../lib/src/index.js";
 import { Course, Section, Timetable } from "./entity/entities.js";
 
 interface ExamJSON {

--- a/backend/src/middleware/logging.ts
+++ b/backend/src/middleware/logging.ts
@@ -1,12 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
 import { default as onFinished } from "on-finished";
-import { ZodError } from "zod";
-
-function isZodError(err: unknown): err is ZodError {
-  return Boolean(
-    err && (err instanceof ZodError || (err as ZodError).name === "ZodError"),
-  );
-}
 
 export const logger = async (
   req: Request,
@@ -34,13 +27,8 @@ export const logger = async (
     if (err || rest.statusCode >= 500) {
       resLogger.error(`${rest.statusCode} ${JSON.stringify(err)}`);
     } else {
-      // since ZodErrors have a different format from our errors, we handle them separately
       resLogger.info(
-        `${rest.statusCode} ${
-          isZodError(rest.body)
-            ? JSON.stringify(rest.body)
-            : (rest.body?.message ?? rest.statusMessage)
-        }`,
+        `${rest.statusCode} ${rest.body?.message ?? rest.statusMessage}`,
       );
     }
   });

--- a/backend/src/middleware/zodValidateRequest.ts
+++ b/backend/src/middleware/zodValidateRequest.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import type { ZodType } from "zod";
+import { ZodError, type ZodType } from "zod";
 
 export const validate =
   (schema: ZodType<any>) =>
@@ -12,6 +12,9 @@ export const validate =
       });
       return next();
     } catch (error) {
-      return res.status(400).json(error);
+      if (error instanceof ZodError) {
+        return res.status(400).json({ message: error.issues[0].message });
+      }
+      return next(error);
     }
   };

--- a/backend/src/repositories/announcementRepository.ts
+++ b/backend/src/repositories/announcementRepository.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from "../db.js";
-import { Announcement } from "../entity/entities.js";
-
-export const announcementRepository = AppDataSource.getRepository(Announcement);

--- a/backend/src/repositories/courseRepository.ts
+++ b/backend/src/repositories/courseRepository.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from "../db.js";
-import { Course } from "../entity/entities.js";
-
-export const courseRepository = AppDataSource.getRepository(Course);

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -1,0 +1,14 @@
+import { AppDataSource } from "../db.js";
+import {
+  Announcement,
+  Course,
+  Section,
+  Timetable,
+  User,
+} from "../entity/entities.js";
+
+export const announcementRepository = AppDataSource.getRepository(Announcement);
+export const courseRepository = AppDataSource.getRepository(Course);
+export const sectionRepository = AppDataSource.getRepository(Section);
+export const timetableRepository = AppDataSource.getRepository(Timetable);
+export const userRepository = AppDataSource.getRepository(User);

--- a/backend/src/repositories/sectionRepository.ts
+++ b/backend/src/repositories/sectionRepository.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from "../db.js";
-import { Section } from "../entity/entities.js";
-
-export const sectionRepository = AppDataSource.getRepository(Section);

--- a/backend/src/repositories/timetableRepository.ts
+++ b/backend/src/repositories/timetableRepository.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from "../db.js";
-import { Timetable } from "../entity/entities.js";
-
-export const timetableRepository = AppDataSource.getRepository(Timetable);

--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from "../db.js";
-import { User } from "../entity/entities.js";
-
-export const userRepository = AppDataSource.getRepository(User);

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -1,14 +1,15 @@
 /*
 These are the types that facilitate authentication
 */
-import { z } from "zod";
+
 import {
   namedDegreeZodList,
   namedEmailType,
   namedIntegerType,
   namedNonEmptyStringType,
   namedUUIDType,
-} from "../../../lib/src/index.js";
+} from "lib";
+import { z } from "zod";
 
 // interface for userdata to be stored in the session cookie and for validating the type of session cookie
 export const ZodUnfinishedUserSession = z.object({

--- a/backend/src/utils/updateWarnings.ts
+++ b/backend/src/utils/updateWarnings.ts
@@ -1,4 +1,4 @@
-import type { sectionTypeList } from "../../../lib/src/index.js";
+import type { sectionTypeList } from "lib";
 import type { Section } from "../entity/entities.js";
 
 export const updateSectionWarnings = (


### PR DESCRIPTION
Mechanical backend cleanup: lib is imported as a package instead of deep relative paths, the five three-line repository files are merged into one, dotenv loads once in config/server.ts so import order no longer matters, and the env schema no longer requires frontend-only vars that the backend never reads. Error paths now all return { message } instead of raw ZodErrors or stack traces, and the frontend never parsed the old ZodError shape so nothing breaks there.

tsc --build and biome ci pass; not run against a live database.
