### PR TITLE
Extract shared timetable controller helpers

### DIFF
--- a/backend/src/controllers/timetable/addSection.ts
+++ b/backend/src/controllers/timetable/addSection.ts
@@ -1,25 +1,26 @@
 import type { Request, Response } from "express";
-import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
+import { namedUUIDType, timetableIDType } from "lib";
 import { z } from "zod";
-import {
-  type Course,
-  type Section,
-  Timetable,
-  type User,
-} from "../../entity/entities.js";
+import { Timetable } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import {
   courseRepository,
   sectionRepository,
   timetableRepository,
-  userRepository,
 } from "../../repositories/index.js";
 import {
   checkForClassHoursClash,
   checkForExamHoursClash,
 } from "../../utils/checkForClashes.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+import { addExamTimings } from "../../utils/updateSection.js";
 import { updateSectionWarnings } from "../../utils/updateWarnings.js";
+import {
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  getCourseSectionTypes,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   body: z.object({
@@ -34,89 +35,65 @@ export const addSectionValidator = validate(dataSchema);
 
 export const addSection = async (req: Request, res: Response) => {
   const logger = req.log;
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
 
   const sectionId = req.body.sectionId;
 
-  let author: User | null = null;
-
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
-  let timetable: Timetable | null = null;
-
-  try {
-    timetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .leftJoinAndSelect("timetable.sections", "section")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const timetable = await fetchTimetableOrError(res, logger, dbID, {
+    authorId: author.id,
+    joinSections: true,
+    mustBeDraft: true,
+    queryErrorLogMessage: "Error while querying timetable: ",
+  });
   if (!timetable) {
-    return res.status(404).json({ message: "timetable not found" });
+    return;
   }
 
-  if (timetable.authorId !== author.id) {
-    return res.status(403).json({ message: "user does not own timetable" });
-  }
-
-  if (!timetable.draft) {
-    return res.status(418).json({ message: "timetable is not a draft" });
-  }
-
-  if (timetable.archived) {
-    return res.status(418).json({ message: "timetable is archived" });
-  }
-
-  let section: Section | null = null;
-
-  try {
-    section = await sectionRepository
-      .createQueryBuilder("section")
-      .where("section.id = :id", { id: sectionId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for section: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const section = await queryOr500(
+    res,
+    logger,
+    "Error while querying for section: ",
+    () =>
+      sectionRepository
+        .createQueryBuilder("section")
+        .where("section.id = :id", { id: sectionId })
+        .getOne(),
+  );
+  if (section === undefined) {
+    return;
   }
 
   if (!section) {
     return res.status(404).json({ message: "section not found" });
   }
 
-  let course: Course | null = null;
   const courseId = section.courseId;
 
-  try {
-    course = await courseRepository
-      .createQueryBuilder("course")
-      .where("course.id = :id", { id: courseId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for course: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const course = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course: ",
+    () =>
+      courseRepository
+        .createQueryBuilder("course")
+        .where("course.id = :id", { id: courseId })
+        .getOne(),
+  );
+  if (course === undefined) {
+    return;
   }
 
   if (!course) {
@@ -141,23 +118,14 @@ export const addSection = async (req: Request, res: Response) => {
     });
   }
 
-  let sectionTypes: sectionTypeList = [];
-
-  try {
-    const sectionTypeHolders = await sectionRepository
-      .createQueryBuilder("section")
-      .select("section.type")
-      .where("section.courseId = :courseId", { courseId: courseId })
-      .distinctOn(["section.type"])
-      .getMany();
-    sectionTypes = sectionTypeHolders.map((section) => section.type);
-  } catch (err: any) {
-    logger.error(
-      "Error while querying for course's section types: ",
-      err.message,
-    );
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const sectionTypes = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course's section types: ",
+    () => getCourseSectionTypes(sectionRepository.manager, courseId),
+  );
+  if (sectionTypes === undefined) {
+    return;
   }
 
   // the timetable's sections were already loaded with it above, so this
@@ -190,64 +158,56 @@ export const addSection = async (req: Request, res: Response) => {
   );
 
   const newExamTimes = timetable.examTimes;
-  if (course.midsemStartTime !== null && course.midsemEndTime !== null) {
-    newExamTimes.push(
-      `${
-        course.code
-      }|MIDSEM|${course.midsemStartTime.toISOString()}|${course.midsemEndTime.toISOString()}`,
-    );
-  }
-  if (course.compreStartTime !== null && course.compreEndTime !== null) {
-    newExamTimes.push(
-      `${
-        course.code
-      }|COMPRE|${course.compreStartTime.toISOString()}|${course.compreEndTime.toISOString()}`,
-    );
-  }
+  addExamTimings(newExamTimes, course);
 
-  try {
-    await timetableRepository.manager.transaction(
-      async (transactionalEntityManager) => {
-        // shoudn't be needed, but kept them here as it was erroring out
-        if (!course) {
-          return res.status(404).json({ message: "course not found" });
-        }
-        if (!timetable) {
-          return res.status(404).json({ message: "timetable not found" });
-        }
+  const updated = await queryOr500(
+    res,
+    logger,
+    "Error while updating timetable with section: ",
+    async () => {
+      await timetableRepository.manager.transaction(
+        async (transactionalEntityManager) => {
+          // shoudn't be needed, but kept them here as it was erroring out
+          if (!course) {
+            return res.status(404).json({ message: "course not found" });
+          }
+          if (!timetable) {
+            return res.status(404).json({ message: "timetable not found" });
+          }
 
-        await transactionalEntityManager
-          .createQueryBuilder()
-          .relation(Timetable, "sections")
-          .of(timetable)
-          .add(section);
+          await transactionalEntityManager
+            .createQueryBuilder()
+            .relation(Timetable, "sections")
+            .of(timetable)
+            .add(section);
 
-        await transactionalEntityManager
-          .createQueryBuilder()
-          .update(Timetable)
-          .set({
-            timings: [...timetable.timings, ...newTimes],
-            warnings: timetable.warnings,
-          })
-          .where("timetable.id = :id", { id: timetable.id })
-          .execute();
-
-        if (!examHourClashes.sameCourse) {
           await transactionalEntityManager
             .createQueryBuilder()
             .update(Timetable)
             .set({
-              examTimes: newExamTimes,
+              timings: [...timetable.timings, ...newTimes],
+              warnings: timetable.warnings,
             })
             .where("timetable.id = :id", { id: timetable.id })
             .execute();
-        }
-      },
-    );
-  } catch (err: any) {
-    logger.error("Error while updating timetable with section: ", err.message);
 
-    return res.status(500).json({ message: "Internal Server Error" });
+          if (!examHourClashes.sameCourse) {
+            await transactionalEntityManager
+              .createQueryBuilder()
+              .update(Timetable)
+              .set({
+                examTimes: newExamTimes,
+              })
+              .where("timetable.id = :id", { id: timetable.id })
+              .execute();
+          }
+        },
+      );
+      return true;
+    },
+  );
+  if (updated === undefined) {
+    return;
   }
   return res.json({ message: "section added" });
 };

--- a/backend/src/controllers/timetable/copyTimetable.ts
+++ b/backend/src/controllers/timetable/copyTimetable.ts
@@ -1,14 +1,17 @@
 import type { Request, Response } from "express";
 import { type degreeEnum, timetableIDType } from "lib";
 import { z } from "zod";
-import { type Section, Timetable, type User } from "../../entity/entities.js";
+import { type Section, Timetable } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
-import {
-  timetableRepository,
-  userRepository,
-} from "../../repositories/index.js";
+import { timetableRepository } from "../../repositories/index.js";
 import timetableJSON from "../../timetable.json" with { type: "json" };
-import sqids, { validSqid } from "../../utils/sqids.js";
+import sqids from "../../utils/sqids.js";
+import {
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   params: z.object({
@@ -20,25 +23,19 @@ export const copyTimetableValidator = validate(dataSchema);
 
 export const copyTimetable = async (req: Request, res: Response) => {
   const logger = req.log;
-  let author: User | null = null;
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
 
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying for user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
   // new timetable default properties
@@ -58,23 +55,13 @@ export const copyTimetable = async (req: Request, res: Response) => {
   const lastUpdated: Date = new Date();
   const authorId: string = author.id;
 
-  let copiedTimetable: Timetable | null = null;
-  try {
-    copiedTimetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .leftJoinAndSelect("timetable.sections", "section")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const copiedTimetable = await fetchTimetableOrError(res, logger, dbID, {
+    joinSections: true,
+    notFoundMessage: "timetable to be copied not found",
+    queryErrorLogMessage: "Error while querying for timetable: ",
+  });
   if (!copiedTimetable) {
-    return res
-      .status(404)
-      .json({ message: "timetable to be copied not found" });
+    return;
   }
 
   if (copiedTimetable.archived) {
@@ -87,56 +74,62 @@ export const copyTimetable = async (req: Request, res: Response) => {
   examTimes = copiedTimetable.examTimes;
   warnings = copiedTimetable.warnings;
 
-  try {
-    const timetable = await timetableRepository
-      .createQueryBuilder()
-      .insert()
-      .into(Timetable)
-      .values({
-        authorId,
-        name,
-        degrees,
-        private: isPrivate,
-        draft: isDraft,
-        archived: isArchived,
-        acadYear,
-        semester,
-        year,
-        sections,
-        timings,
-        examTimes,
-        warnings,
-        createdAt,
-        lastUpdated,
-      })
-      .execute();
-    try {
-      let section: Section | null = null;
-      for (let i = 0; i < copiedTimetable.sections.length; i++) {
-        section = copiedTimetable.sections[i];
-        await timetableRepository
-          .createQueryBuilder()
-          .relation(Timetable, "sections")
-          .of(timetable.identifiers[0].id)
-          .add(section);
-      }
-    } catch (err: any) {
-      logger.error(
+  const timetableID = await queryOr500(
+    res,
+    logger,
+    "Error while copying timetable: ",
+    async () => {
+      const timetable = await timetableRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Timetable)
+        .values({
+          authorId,
+          name,
+          degrees,
+          private: isPrivate,
+          draft: isDraft,
+          archived: isArchived,
+          acadYear,
+          semester,
+          year,
+          sections,
+          timings,
+          examTimes,
+          warnings,
+          createdAt,
+          lastUpdated,
+        })
+        .execute();
+
+      const sectionsCopied = await queryOr500(
+        res,
+        logger,
         "Error while copying sections into new timetable: ",
-        err.message,
+        async () => {
+          for (let i = 0; i < copiedTimetable.sections.length; i++) {
+            const section = copiedTimetable.sections[i];
+            await timetableRepository
+              .createQueryBuilder()
+              .relation(Timetable, "sections")
+              .of(timetable.identifiers[0].id)
+              .add(section);
+          }
+          return true;
+        },
       );
+      if (sectionsCopied === undefined) {
+        return undefined;
+      }
 
-      return res.status(500).json({ message: "Internal Server Error" });
-    }
-
-    const timetableID = sqids.encode([timetable.identifiers[0].id]);
-    return res.status(201).json({
-      message: "Timetable copied successfully",
-      id: timetableID,
-    });
-  } catch (err: any) {
-    logger.error("Error while copying timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+      return sqids.encode([timetable.identifiers[0].id]);
+    },
+  );
+  if (timetableID === undefined) {
+    return;
   }
+  return res.status(201).json({
+    message: "Timetable copied successfully",
+    id: timetableID,
+  });
 };

--- a/backend/src/controllers/timetable/createTimetable.ts
+++ b/backend/src/controllers/timetable/createTimetable.ts
@@ -1,30 +1,21 @@
 import type { Request, Response } from "express";
 import type { degreeEnum } from "lib";
-import { type Section, Timetable, type User } from "../../entity/entities.js";
-import {
-  timetableRepository,
-  userRepository,
-} from "../../repositories/index.js";
+import { type Section, Timetable } from "../../entity/entities.js";
+import { timetableRepository } from "../../repositories/index.js";
 import timetableJSON from "../../timetable.json" with { type: "json" };
 import sqids from "../../utils/sqids.js";
+import { fetchAuthorOrError, queryOr500 } from "./helpers.js";
 
 export const createTimetable = async (req: Request, res: Response) => {
   const logger = req.log;
-  let author: User | null = null;
-
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying for user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
   // new timetable default properties
@@ -44,38 +35,42 @@ export const createTimetable = async (req: Request, res: Response) => {
   const lastUpdated: Date = new Date();
   const authorId: string = author.id;
 
-  try {
-    const createdTimetable = await timetableRepository
-      .createQueryBuilder()
-      .insert()
-      .into(Timetable)
-      .values({
-        authorId,
-        name,
-        degrees,
-        private: isPrivate,
-        draft: isDraft,
-        archived: isArchived,
-        acadYear,
-        semester,
-        year,
-        sections,
-        timings,
-        examTimes,
-        warnings,
-        createdAt,
-        lastUpdated,
-      })
-      .execute();
+  const timetableID = await queryOr500(
+    res,
+    logger,
+    "Error while creating timetable: ",
+    async () => {
+      const createdTimetable = await timetableRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Timetable)
+        .values({
+          authorId,
+          name,
+          degrees,
+          private: isPrivate,
+          draft: isDraft,
+          archived: isArchived,
+          acadYear,
+          semester,
+          year,
+          sections,
+          timings,
+          examTimes,
+          warnings,
+          createdAt,
+          lastUpdated,
+        })
+        .execute();
 
-    const timetableID = sqids.encode([createdTimetable.identifiers[0].id]);
-    return res.status(201).json({
-      message: "Timetable created successfully",
-      id: timetableID,
-    });
-  } catch (err: any) {
-    logger.error("Error while creating timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+      return sqids.encode([createdTimetable.identifiers[0].id]);
+    },
+  );
+  if (timetableID === undefined) {
+    return;
   }
+  return res.status(201).json({
+    message: "Timetable created successfully",
+    id: timetableID,
+  });
 };

--- a/backend/src/controllers/timetable/deleteTimetable.ts
+++ b/backend/src/controllers/timetable/deleteTimetable.ts
@@ -1,13 +1,14 @@
 import type { Request, Response } from "express";
 import { timetableIDType } from "lib";
 import { z } from "zod";
-import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
+import { timetableRepository } from "../../repositories/index.js";
 import {
-  timetableRepository,
-  userRepository,
-} from "../../repositories/index.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   params: z.object({
@@ -19,59 +20,42 @@ export const deleteTimeTableValidator = validate(dataSchema);
 
 export const deleteTimetable = async (req: Request, res: Response) => {
   const logger = req.log;
-  let author: User | null = null;
-
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
 
-  let timetable: Timetable | null = null;
-
-  try {
-    timetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const timetable = await fetchTimetableOrError(res, logger, dbID, {
+    authorId: author.id,
+    queryErrorLogMessage: "Error while querying timetable: ",
+  });
   if (!timetable) {
-    return res.status(404).json({ message: "timetable not found" });
+    return;
   }
 
-  if (timetable.authorId !== author.id) {
-    return res.status(403).json({ message: "user does not own timetable" });
-  }
-
-  try {
-    await timetableRepository
-      .createQueryBuilder("timetable")
-      .delete()
-      .where("timetable.id = :id", { id: timetable.id })
-      .execute();
-  } catch (err: any) {
-    logger.error("Error while deleting timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const deleted = await queryOr500(
+    res,
+    logger,
+    "Error while deleting timetable: ",
+    () =>
+      timetableRepository
+        .createQueryBuilder("timetable")
+        .delete()
+        .where("timetable.id = :id", { id: timetable.id })
+        .execute(),
+  );
+  if (deleted === undefined) {
+    return;
   }
   return res.json({ message: "timetable deleted" });
 };

--- a/backend/src/controllers/timetable/editTimetableMetadata.ts
+++ b/backend/src/controllers/timetable/editTimetableMetadata.ts
@@ -5,13 +5,14 @@ import {
   timetableIDType,
 } from "lib";
 import { z } from "zod";
-import type { Timetable, User } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
+import { timetableRepository } from "../../repositories/index.js";
 import {
-  timetableRepository,
-  userRepository,
-} from "../../repositories/index.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   body: z.object({
@@ -28,24 +29,18 @@ export const editTimetableMetadataValidator = validate(dataSchema);
 
 export const editTimetableMetadata = async (req: Request, res: Response) => {
   const logger = req.log;
-  let author: User | null = null;
-
   const name: string = req.body.name;
   const isPrivate: boolean = req.body.isPrivate;
   const isDraft: boolean = req.body.isDraft;
 
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying user: ", err.message);
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
   if (isDraft && !isPrivate) {
@@ -54,30 +49,18 @@ export const editTimetableMetadata = async (req: Request, res: Response) => {
       .json({ message: "draft timetable can not be public" });
   }
 
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
 
-  let timetable: Timetable | null = null;
-
-  try {
-    timetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .leftJoinAndSelect("timetable.sections", "section")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying timetable: ", err.message);
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const timetable = await fetchTimetableOrError(res, logger, dbID, {
+    authorId: author.id,
+    joinSections: true,
+    queryErrorLogMessage: "Error while querying timetable: ",
+  });
   if (!timetable) {
-    return res.status(404).json({ message: "timetable not found" });
-  }
-
-  if (timetable.authorId !== author.id) {
-    return res.status(403).json({ message: "user does not own timetable" });
+    return;
   }
 
   if (timetable.archived && isDraft) {
@@ -105,16 +88,20 @@ export const editTimetableMetadata = async (req: Request, res: Response) => {
     });
   }
 
-  try {
-    await timetableRepository.save({
-      ...timetable,
-      name: name,
-      private: isPrivate,
-      draft: isDraft,
-    });
-  } catch (err: any) {
-    logger.error("Error while editing timetable: ", err.message);
-    return res.status(500).json({ message: "Internal Server Error" });
+  const saved = await queryOr500(
+    res,
+    logger,
+    "Error while editing timetable: ",
+    () =>
+      timetableRepository.save({
+        ...timetable,
+        name: name,
+        private: isPrivate,
+        draft: isDraft,
+      }),
+  );
+  if (saved === undefined) {
+    return;
   }
 
   return res.json({ message: "timetable edited" });

--- a/backend/src/controllers/timetable/getTimetableById.ts
+++ b/backend/src/controllers/timetable/getTimetableById.ts
@@ -3,7 +3,7 @@ import { timetableIDType } from "lib";
 import { z } from "zod";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import { timetableRepository } from "../../repositories/index.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+import { decodeTimetableSqidOr404 } from "./helpers.js";
 
 const dataSchema = z.object({
   params: z.object({
@@ -17,9 +17,9 @@ export const getTimetableById = async (req: Request, res: Response) => {
   const logger = req.log;
   try {
     const id = req.params.id as string;
-    const dbID = sqids.decode(id);
-    if (!validSqid(dbID)) {
-      return res.status(404).json({ message: "Timetable does not exist" });
+    const dbID = decodeTimetableSqidOr404(req, res);
+    if (dbID === null) {
+      return;
     }
 
     const timetable = await timetableRepository

--- a/backend/src/controllers/timetable/helpers.ts
+++ b/backend/src/controllers/timetable/helpers.ts
@@ -1,0 +1,139 @@
+import type { Request, Response } from "express";
+import type { sectionTypeList } from "lib";
+import type { Logger } from "pino";
+import type { EntityManager } from "typeorm";
+import { Section, type Timetable, type User } from "../../entity/entities.js";
+import {
+  timetableRepository,
+  userRepository,
+} from "../../repositories/index.js";
+import sqids, { validSqid } from "../../utils/sqids.js";
+
+// Runs the given query. On failure, logs `logMessage` with the error and sends
+// a 500 response, then returns undefined so the caller can stop handling the
+// request. Any other value (including null) is the query's own result.
+export const queryOr500 = async <T>(
+  res: Response,
+  logger: Logger,
+  logMessage: string,
+  query: () => Promise<T>,
+): Promise<T | undefined> => {
+  try {
+    return await query();
+  } catch (err: any) {
+    logger.error(logMessage, err.message);
+    res.status(500).json({ message: "Internal Server Error" });
+    return undefined;
+  }
+};
+
+// Fetches the user behind the current session. Sends a 500 on query error and
+// a 401 if the user is not registered; returns null in both cases.
+export const fetchAuthorOrError = async (
+  req: Request,
+  res: Response,
+  logger: Logger,
+  queryErrorLogMessage: string,
+): Promise<User | null> => {
+  const author = await queryOr500(res, logger, queryErrorLogMessage, () =>
+    userRepository
+      .createQueryBuilder("user")
+      .where("user.id = :id", { id: req.session?.id })
+      .getOne(),
+  );
+  if (author === undefined) {
+    return null;
+  }
+  if (!author) {
+    res.status(401).json({ message: "unregistered user" });
+    return null;
+  }
+  return author;
+};
+
+// Decodes the sqid timetable id from the request params. Sends a 404 and
+// returns null if it is not a valid sqid.
+export const decodeTimetableSqidOr404 = (
+  req: Request,
+  res: Response,
+): number[] | null => {
+  const dbID = sqids.decode(req.params.id as string);
+  if (!validSqid(dbID)) {
+    res.status(404).json({ message: "Timetable does not exist" });
+    return null;
+  }
+  return dbID;
+};
+
+// Fetches a timetable by decoded id, optionally loading its sections and
+// enforcing ownership and draft/archived state. Sends the matching error
+// response and returns null on any failure.
+export const fetchTimetableOrError = async (
+  res: Response,
+  logger: Logger,
+  dbID: number[],
+  options: {
+    authorId?: string;
+    joinSections?: boolean;
+    mustBeDraft?: boolean;
+    notFoundMessage?: string;
+    queryErrorLogMessage: string;
+  },
+): Promise<Timetable | null> => {
+  let timetableQuery = timetableRepository
+    .createQueryBuilder("timetable")
+    .where("timetable.id = :id", { id: dbID[0] });
+  if (options.joinSections) {
+    timetableQuery = timetableQuery.leftJoinAndSelect(
+      "timetable.sections",
+      "section",
+    );
+  }
+  const timetable = await queryOr500(
+    res,
+    logger,
+    options.queryErrorLogMessage,
+    () => timetableQuery.getOne(),
+  );
+  if (timetable === undefined) {
+    return null;
+  }
+  if (!timetable) {
+    res
+      .status(404)
+      .json({ message: options.notFoundMessage ?? "timetable not found" });
+    return null;
+  }
+  if (
+    options.authorId !== undefined &&
+    timetable.authorId !== options.authorId
+  ) {
+    res.status(403).json({ message: "user does not own timetable" });
+    return null;
+  }
+  if (options.mustBeDraft) {
+    if (!timetable.draft) {
+      res.status(418).json({ message: "timetable is not a draft" });
+      return null;
+    }
+    if (timetable.archived) {
+      res.status(418).json({ message: "timetable is archived" });
+      return null;
+    }
+  }
+  return timetable;
+};
+
+// Fetches the distinct section types of a course.
+export const getCourseSectionTypes = async (
+  manager: EntityManager,
+  courseId: string,
+): Promise<sectionTypeList> => {
+  const sectionTypeHolders = await manager
+    .createQueryBuilder(Section, "section")
+    .select("section.type")
+    .where("section.courseId = :courseId", { courseId })
+    .distinctOn(["section.type"])
+    .getMany();
+  return sectionTypeHolders.map((section) => section.type);
+};

--- a/backend/src/controllers/timetable/removeSection.ts
+++ b/backend/src/controllers/timetable/removeSection.ts
@@ -1,21 +1,22 @@
 import type { Request, Response } from "express";
-import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
+import { namedUUIDType, timetableIDType } from "lib";
 import { z } from "zod";
-import type {
-  Course,
-  Section,
-  Timetable,
-  User,
-} from "../../entity/entities.js";
+import type { Section } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import {
   courseRepository,
   sectionRepository,
   timetableRepository,
-  userRepository,
 } from "../../repositories/index.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+import { removeSection as removeSectionFromTimetable } from "../../utils/updateSection.js";
 import { updateSectionWarnings } from "../../utils/updateWarnings.js";
+import {
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  getCourseSectionTypes,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   body: z.object({
@@ -30,70 +31,44 @@ export const removeSectionValidator = validate(dataSchema);
 
 export const removeSection = async (req: Request, res: Response) => {
   const logger = req.log;
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
   const sectionId = req.body.sectionId;
 
-  let author: User | null = null;
-
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
-  let timetable: Timetable | null = null;
-
-  try {
-    timetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .leftJoinAndSelect("timetable.sections", "section")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const timetable = await fetchTimetableOrError(res, logger, dbID, {
+    authorId: author.id,
+    joinSections: true,
+    mustBeDraft: true,
+    queryErrorLogMessage: "Error while querying timetable: ",
+  });
   if (!timetable) {
-    return res.status(404).json({ message: "timetable not found" });
+    return;
   }
 
-  if (timetable.authorId !== author.id) {
-    return res.status(403).json({ message: "user does not own timetable" });
-  }
-
-  if (!timetable.draft) {
-    return res.status(418).json({ message: "timetable is not a draft" });
-  }
-
-  if (timetable.archived) {
-    return res.status(418).json({ message: "timetable is archived" });
-  }
-
-  let section: Section | null = null;
-
-  try {
-    section = await sectionRepository
-      .createQueryBuilder("section")
-      .where("section.id = :sectionId", { sectionId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for section: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const section = await queryOr500(
+    res,
+    logger,
+    "Error while querying for section: ",
+    () =>
+      sectionRepository
+        .createQueryBuilder("section")
+        .where("section.id = :sectionId", { sectionId })
+        .getOne(),
+  );
+  if (section === undefined) {
+    return;
   }
 
   if (section === null) {
@@ -115,18 +90,20 @@ export const removeSection = async (req: Request, res: Response) => {
     });
   }
 
-  let course: Course | null = null;
   const courseId = section.courseId;
 
-  try {
-    course = await courseRepository
-      .createQueryBuilder("course")
-      .where("course.id = :id", { id: courseId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for course: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const course = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course: ",
+    () =>
+      courseRepository
+        .createQueryBuilder("course")
+        .where("course.id = :id", { id: courseId })
+        .getOne(),
+  );
+  if (course === undefined) {
+    return;
   }
 
   if (!course) {
@@ -150,36 +127,17 @@ export const removeSection = async (req: Request, res: Response) => {
     });
   }
 
-  let sectionTypes: sectionTypeList = [];
-
-  try {
-    const sectionTypeHolders = await sectionRepository
-      .createQueryBuilder("section")
-      .select("section.type")
-      .where("section.courseId = :courseId", { courseId: courseId })
-      .distinctOn(["section.type"])
-      .getMany();
-    sectionTypes = sectionTypeHolders.map((section) => section.type);
-  } catch (err: any) {
-    logger.error(
-      "Error while querying for course's section types: ",
-      err.message,
-    );
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const sectionTypes = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course's section types: ",
+    () => getCourseSectionTypes(sectionRepository.manager, courseId),
+  );
+  if (sectionTypes === undefined) {
+    return;
   }
 
-  const classTimings = section.roomTime.map((time) => {
-    return time.split(":")[2] + time.split(":")[3];
-  });
-
-  timetable.timings = timetable.timings.filter((time) => {
-    return !classTimings.includes(time.split(":")[1]);
-  });
-
-  timetable.sections = timetable.sections.filter((currentSection) => {
-    return currentSection.id !== section?.id;
-  });
+  removeSectionFromTimetable(timetable, section);
 
   try {
     timetable.warnings = updateSectionWarnings(
@@ -200,12 +158,14 @@ export const removeSection = async (req: Request, res: Response) => {
     });
   }
 
-  try {
-    await timetableRepository.save(timetable);
-  } catch (err: any) {
-    logger.error("Error while removing section from timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const saved = await queryOr500(
+    res,
+    logger,
+    "Error while removing section from timetable: ",
+    () => timetableRepository.save(timetable),
+  );
+  if (saved === undefined) {
+    return;
   }
 
   return res.json({ message: "section removed" });

--- a/backend/src/controllers/timetable/swapSections.ts
+++ b/backend/src/controllers/timetable/swapSections.ts
@@ -1,25 +1,29 @@
 import type { Request, Response } from "express";
-import { namedUUIDType, type sectionTypeList, timetableIDType } from "lib";
+import { namedUUIDType, timetableIDType } from "lib";
 import { z } from "zod";
-import {
-  type Course,
-  type Section,
-  Timetable,
-  type User,
-} from "../../entity/entities.js";
+import { type Section, Timetable } from "../../entity/entities.js";
 import { validate } from "../../middleware/zodValidateRequest.js";
 import {
   courseRepository,
   sectionRepository,
   timetableRepository,
-  userRepository,
 } from "../../repositories/index.js";
 import {
   checkForClassHoursClash,
   checkForExamHoursClash,
 } from "../../utils/checkForClashes.js";
-import sqids, { validSqid } from "../../utils/sqids.js";
+import {
+  addExamTimings,
+  removeSection as removeSectionFromTimetable,
+} from "../../utils/updateSection.js";
 import { updateSectionWarnings } from "../../utils/updateWarnings.js";
+import {
+  decodeTimetableSqidOr404,
+  fetchAuthorOrError,
+  fetchTimetableOrError,
+  getCourseSectionTypes,
+  queryOr500,
+} from "./helpers.js";
 
 const dataSchema = z.object({
   body: z.object({
@@ -35,75 +39,49 @@ export const swapSectionsValidator = validate(dataSchema);
 
 export const swapSections = async (req: Request, res: Response) => {
   const logger = req.log;
-  const dbID = sqids.decode(req.params.id as string);
-  if (!validSqid(dbID)) {
-    return res.status(404).json({ message: "Timetable does not exist" });
+  const dbID = decodeTimetableSqidOr404(req, res);
+  if (dbID === null) {
+    return;
   }
   const sectionId = req.body.sectionId;
   const newSectionId = req.body.newSectionId;
 
   // Common checks
 
-  let author: User | null = null;
-
-  try {
-    author = await userRepository
-      .createQueryBuilder("user")
-      .where("user.id = :id", { id: req.session?.id })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying user: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const author = await fetchAuthorOrError(
+    req,
+    res,
+    logger,
+    "Error while querying user: ",
+  );
   if (!author) {
-    return res.status(401).json({ message: "unregistered user" });
+    return;
   }
 
-  let timetable: Timetable | null = null;
-
-  try {
-    timetable = await timetableRepository
-      .createQueryBuilder("timetable")
-      .leftJoinAndSelect("timetable.sections", "section")
-      .where("timetable.id = :id", { id: dbID[0] })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying timetable: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
-  }
-
+  const timetable = await fetchTimetableOrError(res, logger, dbID, {
+    authorId: author.id,
+    joinSections: true,
+    mustBeDraft: true,
+    queryErrorLogMessage: "Error while querying timetable: ",
+  });
   if (!timetable) {
-    return res.status(404).json({ message: "timetable not found" });
-  }
-
-  if (timetable.authorId !== author.id) {
-    return res.status(403).json({ message: "user does not own timetable" });
-  }
-
-  if (!timetable.draft) {
-    return res.status(418).json({ message: "timetable is not a draft" });
-  }
-
-  if (timetable.archived) {
-    return res.status(418).json({ message: "timetable is archived" });
+    return;
   }
 
   // Checks that removeSection makes
 
-  let section: Section | null = null;
-
-  try {
-    section = await sectionRepository
-      .createQueryBuilder("section")
-      .where("section.id = :sectionId", { sectionId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for section: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const section = await queryOr500(
+    res,
+    logger,
+    "Error while querying for section: ",
+    () =>
+      sectionRepository
+        .createQueryBuilder("section")
+        .where("section.id = :sectionId", { sectionId })
+        .getOne(),
+  );
+  if (section === undefined) {
+    return;
   }
 
   if (section === null) {
@@ -127,39 +105,50 @@ export const swapSections = async (req: Request, res: Response) => {
 
   // Checks that addSection makes
 
-  let newSection: Section | null = null;
-
-  try {
-    newSection = await sectionRepository
-      .createQueryBuilder("section")
-      .where("section.id = :newSectionId", { newSectionId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for new section: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const newSection = await queryOr500(
+    res,
+    logger,
+    "Error while querying for new section: ",
+    () =>
+      sectionRepository
+        .createQueryBuilder("section")
+        .where("section.id = :newSectionId", { newSectionId })
+        .getOne(),
+  );
+  if (newSection === undefined) {
+    return;
   }
 
   if (newSection === null) {
     return res.status(404).json({ message: "New section not found" });
   }
 
-  let course: Course | null = null;
-  let newCourse: Course | null = null;
+  const course = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course: ",
+    () =>
+      courseRepository
+        .createQueryBuilder("course")
+        .where("course.id = :id", { id: section.courseId })
+        .getOne(),
+  );
+  if (course === undefined) {
+    return;
+  }
 
-  try {
-    course = await courseRepository
-      .createQueryBuilder("course")
-      .where("course.id = :id", { id: section.courseId })
-      .getOne();
-    newCourse = await courseRepository
-      .createQueryBuilder("course")
-      .where("course.id = :id", { id: newSection.courseId })
-      .getOne();
-  } catch (err: any) {
-    logger.error("Error while querying for course: ", err.message);
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const newCourse = await queryOr500(
+    res,
+    logger,
+    "Error while querying for course: ",
+    () =>
+      courseRepository
+        .createQueryBuilder("course")
+        .where("course.id = :id", { id: newSection.courseId })
+        .getOne(),
+  );
+  if (newCourse === undefined) {
+    return;
   }
 
   if (!course || !newCourse) {
@@ -170,32 +159,24 @@ export const swapSections = async (req: Request, res: Response) => {
     return res.status(418).json({ message: "course is archived" });
   }
 
-  let sectionTypes: sectionTypeList = [];
-  let newSectionTypes: sectionTypeList = [];
+  const sectionTypes = await queryOr500(
+    res,
+    logger,
+    "Error while querying for courses' section types: ",
+    () => getCourseSectionTypes(sectionRepository.manager, course.id),
+  );
+  if (sectionTypes === undefined) {
+    return;
+  }
 
-  try {
-    const sectionTypeHolders = await sectionRepository
-      .createQueryBuilder("section")
-      .select("section.type")
-      .where("section.courseId = :courseId", { courseId: course.id })
-      .distinctOn(["section.type"])
-      .getMany();
-    sectionTypes = sectionTypeHolders.map((section) => section.type);
-
-    const newSectionTypeHolders = await sectionRepository
-      .createQueryBuilder("section")
-      .select("section.type")
-      .where("section.courseId = :courseId", { courseId: newCourse.id })
-      .distinctOn(["section.type"])
-      .getMany();
-    newSectionTypes = newSectionTypeHolders.map((section) => section.type);
-  } catch (err: any) {
-    logger.error(
-      "Error while querying for courses' section types: ",
-      err.message,
-    );
-
-    return res.status(500).json({ message: "Internal Server Error" });
+  const newSectionTypes = await queryOr500(
+    res,
+    logger,
+    "Error while querying for courses' section types: ",
+    () => getCourseSectionTypes(sectionRepository.manager, newCourse.id),
+  );
+  if (newSectionTypes === undefined) {
+    return;
   }
 
   // Here we update the state of the timetable in-memory and see if it violates any of our clash rules
@@ -213,17 +194,7 @@ export const swapSections = async (req: Request, res: Response) => {
     });
   }
 
-  const classTimings = section.roomTime.map((time) => {
-    return time.split(":")[2] + time.split(":")[3];
-  });
-
-  timetable.timings = timetable.timings.filter((time) => {
-    return !classTimings.includes(time.split(":")[1]);
-  });
-
-  timetable.sections = timetable.sections.filter((currentSection) => {
-    return currentSection.id !== section?.id;
-  });
+  removeSectionFromTimetable(timetable, section);
 
   try {
     timetable.warnings = updateSectionWarnings(
@@ -286,67 +257,59 @@ export const swapSections = async (req: Request, res: Response) => {
   );
 
   const newExamTimes = timetable.examTimes;
-  if (newCourse.midsemStartTime !== null && newCourse.midsemEndTime !== null) {
-    newExamTimes.push(
-      `${
-        newCourse.code
-      }|MIDSEM|${newCourse.midsemStartTime.toISOString()}|${newCourse.midsemEndTime.toISOString()}`,
-    );
-  }
-  if (newCourse.compreStartTime !== null && newCourse.compreEndTime !== null) {
-    newExamTimes.push(
-      `${
-        newCourse.code
-      }|COMPRE|${newCourse.compreStartTime.toISOString()}|${newCourse.compreEndTime.toISOString()}`,
-    );
-  }
+  addExamTimings(newExamTimes, newCourse);
 
   // Finally once we have decided that the swap is valid we write to db in a safe transaction
-  try {
-    await timetableRepository.manager.transaction(
-      async (transactionalEntityManager) => {
-        if (!timetable) {
-          return res.status(404).json({ message: "timetable not found" });
-        }
+  const swapped = await queryOr500(
+    res,
+    logger,
+    "Error while swapping sections: ",
+    async () => {
+      await timetableRepository.manager.transaction(
+        async (transactionalEntityManager) => {
+          if (!timetable) {
+            return res.status(404).json({ message: "timetable not found" });
+          }
 
-        await transactionalEntityManager
-          .createQueryBuilder()
-          .relation(Timetable, "sections")
-          .of(timetable)
-          .remove(section);
+          await transactionalEntityManager
+            .createQueryBuilder()
+            .relation(Timetable, "sections")
+            .of(timetable)
+            .remove(section);
 
-        await transactionalEntityManager
-          .createQueryBuilder()
-          .relation(Timetable, "sections")
-          .of(timetable)
-          .add(newSection);
+          await transactionalEntityManager
+            .createQueryBuilder()
+            .relation(Timetable, "sections")
+            .of(timetable)
+            .add(newSection);
 
-        await transactionalEntityManager
-          .createQueryBuilder()
-          .update(Timetable)
-          .set({
-            timings: [...timetable.timings, ...newTimes],
-            warnings: timetable.warnings,
-          })
-          .where("timetable.id = :id", { id: timetable.id })
-          .execute();
-
-        if (!examHourClashes.sameCourse) {
           await transactionalEntityManager
             .createQueryBuilder()
             .update(Timetable)
             .set({
-              examTimes: newExamTimes,
+              timings: [...timetable.timings, ...newTimes],
+              warnings: timetable.warnings,
             })
             .where("timetable.id = :id", { id: timetable.id })
             .execute();
-        }
-      },
-    );
-  } catch (err: any) {
-    logger.error("Error while swapping sections: ", err.message);
 
-    return res.status(500).json({ message: "Internal Server Error" });
+          if (!examHourClashes.sameCourse) {
+            await transactionalEntityManager
+              .createQueryBuilder()
+              .update(Timetable)
+              .set({
+                examTimes: newExamTimes,
+              })
+              .where("timetable.id = :id", { id: timetable.id })
+              .execute();
+          }
+        },
+      );
+      return true;
+    },
+  );
+  if (swapped === undefined) {
+    return;
   }
   return res.json({ message: "section swapped" });
 };

--- a/backend/src/controllers/timetable/updateChangedTimetable.ts
+++ b/backend/src/controllers/timetable/updateChangedTimetable.ts
@@ -16,6 +16,7 @@ import {
 } from "../../utils/checkForClashes.js";
 import { addExamTimings, removeSection } from "../../utils/updateSection.js";
 import { updateSectionWarnings } from "../../utils/updateWarnings.js";
+import { getCourseSectionTypes } from "./helpers.js";
 
 const dataSchema = z.object({
   body: z.object({
@@ -52,14 +53,9 @@ export const updateChangedTimetable = async (req: Request, res: Response) => {
       .execute();
 
     // Fetch the total types of sections of that course (required later to update warnings)
-    const sectionTypeHolders = await queryRunner.manager
-      .createQueryBuilder(Section, "section")
-      .select("section.type")
-      .where("section.courseId = :courseId", { courseId: course.id })
-      .distinctOn(["section.type"])
-      .getMany();
-    const requiredSectionTypes: sectionTypeList = sectionTypeHolders.map(
-      (section) => section.type,
+    const requiredSectionTypes: sectionTypeList = await getCourseSectionTypes(
+      queryRunner.manager,
+      course.id,
     );
 
     // Fetch the timetables that are affected, archived timetables cannot be affected


### PR DESCRIPTION
The eight timetable controllers were about 40 percent copy-paste: author fetch, sqid decode, ownership checks, try/catch 500 wrappers, and section-type queries repeated six or seven times. This extracts the shared pieces into controllers/timetable/helpers.ts and makes the inline exam-times and remove-section blocks reuse utils/updateSection.ts, so each controller now shows only its unique logic. No behavior change intended: status codes, response bodies, and log strings were diffed against master to confirm.

tsc and biome pass; worth a dev smoke of add, remove and swap section before merging.
