### PR TITLE
Fix and unify frontend data access

### DIFF
--- a/frontend/src/AuthenticatedRoute.tsx
+++ b/frontend/src/AuthenticatedRoute.tsx
@@ -1,24 +1,15 @@
 import { Outlet, Route, redirect } from "@tanstack/react-router";
 import { AxiosError } from "axios";
-import { z } from "zod";
 import { NavBar } from "./components/Navbar";
-import chronoAPI from "./data-access/axios";
+import { authStatusQueryOptions } from "./data-access/hooks/useAuthStatus";
 import { rootRoute } from "./router";
-
-const userAuthStatusType = z.object({
-  message: z.string(),
-  redirect: z.string().optional(),
-  error: z.string().optional(),
-});
 
 const authenticatedRoute = new Route({
   id: "authenticated",
   getParentRoute: () => rootRoute,
-  beforeLoad: async () => {
+  beforeLoad: async ({ context: { queryClient } }) => {
     try {
-      await chronoAPI.get<z.infer<typeof userAuthStatusType>>(
-        "/api/auth/check",
-      );
+      await queryClient.ensureQueryData(authStatusQueryOptions);
     } catch (e) {
       if (e instanceof AxiosError && e.response) {
         if (

--- a/frontend/src/data-access/errors/toastHandler.ts
+++ b/frontend/src/data-access/errors/toastHandler.ts
@@ -8,7 +8,7 @@ const toastHandler = (error: Error, toaster: typeof toast) => {
     switch (error.response.status) {
       case 401:
         handleLoginRedirect(error);
-        break;
+        return;
       default:
         toaster(HTTPError(error.response, error.response.status));
         return;

--- a/frontend/src/data-access/hooks/useCourse.ts
+++ b/frontend/src/data-access/hooks/useCourse.ts
@@ -1,20 +1,23 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import type { courseWithSectionsType } from "lib";
 import type z from "zod";
 import chronoAPI from "../axios";
 
-const fetchCourse = async (currentCourseID: string | null) => {
-  if (currentCourseID === null) return null;
+const fetchCourse = async (currentCourseID: string) => {
   const response = await chronoAPI.get<z.infer<typeof courseWithSectionsType>>(
     `/api/course/${currentCourseID}`,
   );
   return response.data;
 };
 
-const useCourse = (currentCourseID: string | null) =>
-  useQuery({
-    queryKey: [currentCourseID],
-    queryFn: () => fetchCourse(currentCourseID),
+export const courseByIdQueryOptions = (currentCourseID: string | null) =>
+  queryOptions({
+    queryKey: ["course", currentCourseID],
+    queryFn: () => fetchCourse(currentCourseID as string),
+    enabled: currentCourseID !== null,
   });
+
+const useCourse = (currentCourseID: string | null) =>
+  useQuery(courseByIdQueryOptions(currentCourseID));
 
 export default useCourse;


### PR DESCRIPTION
Three small fixes: the 401 branch in toastHandler now returns after redirecting instead of also toasting Unknown Error, AuthenticatedRoute reuses authStatusQueryOptions instead of a hand-rolled fetch with its own error branching, and useCourse follows the same conventions as the other hooks. The new query options export is named courseByIdQueryOptions because courseQueryOptions was already taken.

Frontend build and biome pass.
