### PR TITLE
Extract shared timetable page shell

### DIFF
--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -153,8 +153,8 @@ const TimetableHeader = ({
               className="rounded-full p-3"
               onClick={() => {
                 dispatch({
-                  type: TimetableActionType.SetLoading,
-                  loading: true,
+                  type: TimetableActionType.SetIsCopyingTimetable,
+                  isCopyingTimetable: true,
                 });
                 setTimeout(() => {
                   copyTimetable(timetable.id, {
@@ -166,8 +166,8 @@ const TimetableHeader = ({
                   });
                   setTimeout(() => {
                     dispatch({
-                      type: TimetableActionType.SetLoading,
-                      loading: false,
+                      type: TimetableActionType.SetIsCopyingTimetable,
+                      isCopyingTimetable: false,
                     });
                   }, 1000);
                 }, 1000);

--- a/frontend/src/components/TimetablePageShell.tsx
+++ b/frontend/src/components/TimetablePageShell.tsx
@@ -1,0 +1,112 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { Menu } from "lucide-react";
+import type React from "react";
+import Spinner from "@/components/Spinner";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useToast } from "@/components/ui/use-toast";
+import { useTimetableState } from "@/context";
+import {
+  handleLoginRedirect,
+  handleNotFound,
+} from "@/data-access/errors/handlers";
+import toastHandler from "@/data-access/errors/toastHandler";
+import { courseQueryOptions } from "@/data-access/hooks/useCourses";
+import { timetableQueryOptions } from "@/data-access/hooks/useTimetable";
+import { userQueryOptions } from "@/data-access/hooks/useUser";
+import { cn } from "@/lib/utils";
+
+export const timetablePageLoader = async ({
+  context: { queryClient },
+  params: { timetableId },
+}: {
+  context: { queryClient: QueryClient };
+  params: { timetableId: string };
+}) => {
+  queryClient.ensureQueryData(userQueryOptions);
+  // Courses are fetched for the semester of the timetable, so the timetable
+  // has to be loaded first. Awaiting both keeps this data in the loader, so
+  // preloading warms it before navigation (see
+  // https://tanstack.com/router/v1/docs/guide/data-loading)
+  const timetable = await queryClient.ensureQueryData(
+    timetableQueryOptions(timetableId),
+  );
+  await queryClient.ensureQueryData(
+    courseQueryOptions({
+      acadYear: timetable.acadYear,
+      semester: timetable.semester,
+    }),
+  );
+};
+
+export const TimetablePageError = ({ error }: { error: Error }) => {
+  const { toast } = useToast();
+  handleLoginRedirect(error);
+  handleNotFound(error);
+  toastHandler(error, toast);
+};
+
+export const TimetablePageShell = ({
+  header,
+  sidebar,
+  contentRef,
+  contentClassName,
+  popoverTriggerClassName,
+  children,
+}: {
+  header: React.ReactNode;
+  sidebar: React.ReactNode;
+  contentRef?: React.Ref<HTMLDivElement>;
+  contentClassName?: string;
+  popoverTriggerClassName?: string;
+  children: React.ReactNode;
+}) => {
+  const {
+    state: { isLoading, screenIsLarge },
+  } = useTimetableState();
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col text-muted-foreground gap-8 xl:text-xl lg:text-lg md:text-md text-sm bg-background h-[calc(100dvh-5rem)] justify-center w-full items-center">
+        <Spinner />
+        <span>Please wait while we copy over your timetable...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grow h-[calc(100vh-12rem)]">
+      <TooltipProvider>
+        {header}
+        <div
+          className={cn(
+            "flex flex-row gap-4 h-full relative",
+            contentClassName,
+          )}
+          ref={contentRef}
+        >
+          {screenIsLarge ? (
+            sidebar
+          ) : (
+            <Popover>
+              <PopoverTrigger
+                className={cn("absolute left-2", popoverTriggerClassName)}
+              >
+                <Button variant={"default"} className="rounded-full">
+                  <Menu />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent>{sidebar}</PopoverContent>
+            </Popover>
+          )}
+          {children}
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+};

--- a/frontend/src/components/TimetablePageShell.tsx
+++ b/frontend/src/components/TimetablePageShell.tsx
@@ -67,10 +67,10 @@ export const TimetablePageShell = ({
   children: React.ReactNode;
 }) => {
   const {
-    state: { isLoading, screenIsLarge },
+    state: { isCopyingTimetable, screenIsLarge },
   } = useTimetableState();
 
-  if (isLoading) {
+  if (isCopyingTimetable) {
     return (
       <div className="flex flex-col text-muted-foreground gap-8 xl:text-xl lg:text-lg md:text-md text-sm bg-background h-[calc(100dvh-5rem)] justify-center w-full items-center">
         <Spinner />

--- a/frontend/src/context/context.tsx
+++ b/frontend/src/context/context.tsx
@@ -16,7 +16,7 @@ import {
 
 const initialTimetableState: TimetableStateType = {
   isVertical: false,
-  isLoading: false,
+  isCopyingTimetable: false,
   user: undefined,
   courses: undefined,
   timetable: undefined,

--- a/frontend/src/context/reducer.ts
+++ b/frontend/src/context/reducer.ts
@@ -17,8 +17,8 @@ const reducer: Reducer<TimetableStateType, Action> = (
   switch (action.type) {
     case TimetableActionType.ToggleVertical:
       return { ...state, isVertical: !state.isVertical };
-    case TimetableActionType.SetLoading:
-      return { ...state, isLoading: action.loading };
+    case TimetableActionType.SetIsCopyingTimetable:
+      return { ...state, isCopyingTimetable: action.isCopyingTimetable };
     case TimetableActionType.SetSelectedCourseAndSection:
       return {
         ...state,

--- a/frontend/src/context/types.ts
+++ b/frontend/src/context/types.ts
@@ -27,7 +27,7 @@ type TabType = "CDCs" | "search" | "currentCourses" | "exams";
 
 export type TimetableStateType = {
   isVertical: boolean;
-  isLoading: boolean;
+  isCopyingTimetable: boolean;
   user: z.infer<typeof userWithTimetablesType> | undefined;
   courses: z.infer<typeof courseType>[] | undefined;
   timetable: z.infer<typeof timetableWithSectionsType> | undefined;
@@ -44,7 +44,7 @@ export type TimetableStateType = {
 
 export enum TimetableActionType {
   ToggleVertical = 0,
-  SetLoading = 1,
+  SetIsCopyingTimetable = 1,
   SetSelectedCourseAndSection = 2,
   SetSelectedSectionType = 3,
   SetMenuTab = 4,
@@ -59,8 +59,8 @@ export type Action =
       type: TimetableActionType.ToggleVertical;
     }
   | {
-      type: TimetableActionType.SetLoading;
-      loading: boolean;
+      type: TimetableActionType.SetIsCopyingTimetable;
+      isCopyingTimetable: boolean;
     }
   | {
       type: TimetableActionType.SetSelectedCourseAndSection;

--- a/frontend/src/pages/EditTimetable.tsx
+++ b/frontend/src/pages/EditTimetable.tsx
@@ -1,58 +1,31 @@
 import { Route } from "@tanstack/react-router";
-import { Menu } from "lucide-react";
 import { useEffect } from "react";
 import CourseDetailsMenu from "@/components/CourseDetailsMenu";
 import ReportIssue from "@/components/ReportIssue";
 import TimetableHeader from "@/components/TimetableHeader";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  TimetablePageError,
+  TimetablePageShell,
+  timetablePageLoader,
+} from "@/components/TimetablePageShell";
 import {
   TimetableActionType,
   TimetableProvider,
   useTimetableState,
 } from "@/context";
-import {
-  handleLoginRedirect,
-  handleNotFound,
-} from "@/data-access/errors/handlers";
-import toastHandler from "@/data-access/errors/toastHandler";
-import { courseQueryOptions } from "@/data-access/hooks/useCourses";
-import { timetableQueryOptions } from "@/data-access/hooks/useTimetable";
 import { useAddRemoveTimetableSection } from "@/data-access/hooks/useTimetableSectionAction";
-import { userQueryOptions } from "@/data-access/hooks/useUser";
 import authenticatedRoute from "../AuthenticatedRoute";
 import CenteredSpinner from "../components/CenteredSpinner";
 import NotFound from "../components/NotFound";
 import { SideMenu } from "../components/SideMenu";
-import Spinner from "../components/Spinner";
 import { TimetableGrid } from "../components/TimetableGrid";
-import { Button } from "../components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../components/ui/popover";
-import { toast, useToast } from "../components/ui/use-toast";
+import { toast } from "../components/ui/use-toast";
 import { router } from "../router";
 
 const editTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,
   path: "edit/$timetableId",
-  loader: async ({ context: { queryClient }, params: { timetableId } }) => {
-    queryClient.ensureQueryData(userQueryOptions);
-    // Courses are fetched for the semester of the timetable being edited, so
-    // the timetable has to be loaded first. Awaiting both keeps this data in
-    // the loader, so preloading warms it before navigation (see
-    // https://tanstack.com/router/v1/docs/guide/data-loading)
-    const timetable = await queryClient.ensureQueryData(
-      timetableQueryOptions(timetableId),
-    );
-    await queryClient.ensureQueryData(
-      courseQueryOptions({
-        acadYear: timetable.acadYear,
-        semester: timetable.semester,
-      }),
-    );
-  },
+  loader: timetablePageLoader,
   pendingComponent: CenteredSpinner,
   component: () => (
     <TimetableProvider>
@@ -60,19 +33,13 @@ const editTimetableRoute = new Route({
     </TimetableProvider>
   ),
   notFoundComponent: NotFound,
-  errorComponent: ({ error }) => {
-    const { toast } = useToast();
-    handleLoginRedirect(error);
-    handleNotFound(error);
-    toastHandler(error, toast);
-  },
+  errorComponent: TimetablePageError,
 });
 
 function EditTimetable() {
   const {
     state: {
       isVertical,
-      isLoading,
       user,
       courses,
       timetable,
@@ -123,62 +90,37 @@ function EditTimetable() {
     );
 
   return (
-    <>
-      {isLoading ? (
-        <div className="flex flex-col text-muted-foreground gap-8 xl:text-xl lg:text-lg md:text-md text-sm bg-background h-[calc(100dvh-5rem)] justify-center w-full items-center">
-          <Spinner />
-          <span>Please wait while we copy over your timetable...</span>
-        </div>
-      ) : (
-        <div className="grow h-[calc(100vh-12rem)]">
-          <TooltipProvider>
-            <TimetableHeader isOnEditPage={true} />
-            <div className="flex flex-row gap-4 h-full relative">
-              {screenIsLarge ? (
-                SideBar
-              ) : (
-                <Popover>
-                  <PopoverTrigger className="absolute left-2">
-                    <Button variant={"default"} className="rounded-full">
-                      <Menu />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent>{SideBar}</PopoverContent>
-                </Popover>
-              )}
-              <TimetableGrid
-                isVertical={screenIsLarge ? isVertical : true}
-                handleUnitClick={(e, event) => {
-                  if (e?.courseId && e?.type) {
-                    if (event.detail === 1) {
-                      dispatch({
-                        type: TimetableActionType.SetSelectedCourseAndSection,
-                        courseID: courses.filter(
-                          (x) => x.code === e?.courseId,
-                        )[0].id,
-                        sectionType: e?.type as "L" | "P" | "T",
-                      });
-                    } else if (event.detail >= 2) {
-                      e?.id
-                        ? sectionAction({ sectionId: e?.id, action: "remove" })
-                        : console.log("error:", e);
-                    }
-                  } else {
-                    console.log("error:", e);
-                  }
-                }}
-                handleUnitDelete={(e) => {
-                  e?.id
-                    ? sectionAction({ sectionId: e?.id, action: "remove" })
-                    : console.log("error:", e);
-                }}
-                isOnEditPage={true}
-              />
-            </div>
-          </TooltipProvider>
-        </div>
-      )}
-    </>
+    <TimetablePageShell
+      header={<TimetableHeader isOnEditPage={true} />}
+      sidebar={SideBar}
+    >
+      <TimetableGrid
+        isVertical={screenIsLarge ? isVertical : true}
+        handleUnitClick={(e, event) => {
+          if (e?.courseId && e?.type) {
+            if (event.detail === 1) {
+              dispatch({
+                type: TimetableActionType.SetSelectedCourseAndSection,
+                courseID: courses.filter((x) => x.code === e?.courseId)[0].id,
+                sectionType: e?.type as "L" | "P" | "T",
+              });
+            } else if (event.detail >= 2) {
+              e?.id
+                ? sectionAction({ sectionId: e?.id, action: "remove" })
+                : console.log("error:", e);
+            }
+          } else {
+            console.log("error:", e);
+          }
+        }}
+        handleUnitDelete={(e) => {
+          e?.id
+            ? sectionAction({ sectionId: e?.id, action: "remove" })
+            : console.log("error:", e);
+        }}
+        isOnEditPage={true}
+      />
+    </TimetablePageShell>
   );
 }
 

--- a/frontend/src/pages/FinalizeTimetable.tsx
+++ b/frontend/src/pages/FinalizeTimetable.tsx
@@ -2,17 +2,13 @@ import { Route } from "@tanstack/react-router";
 import { Clipboard, ClipboardCheck, Globe, Lock } from "lucide-react";
 import { useRef, useState } from "react";
 import ReportIssue from "@/components/ReportIssue";
+import { TimetablePageError } from "@/components/TimetablePageShell";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  handleLoginRedirect,
-  handleNotFound,
-} from "@/data-access/errors/handlers";
-import toastHandler from "@/data-access/errors/toastHandler";
 import useEditTimetable from "@/data-access/hooks/useEditTimetable";
 import useTimetable, {
   timetableQueryOptions,
@@ -21,7 +17,6 @@ import authenticatedRoute from "../AuthenticatedRoute";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
-import { useToast } from "../components/ui/use-toast";
 import { router } from "../router";
 
 const finalizeTimetableRoute = new Route({
@@ -30,12 +25,7 @@ const finalizeTimetableRoute = new Route({
   loader: ({ context: { queryClient }, params: { timetableId } }) =>
     queryClient.ensureQueryData(timetableQueryOptions(timetableId)),
   component: FinalizeTimetable,
-  errorComponent: ({ error }) => {
-    const { toast } = useToast();
-    handleLoginRedirect(error);
-    handleNotFound(error);
-    toastHandler(error, toast);
-  },
+  errorComponent: TimetablePageError,
 });
 
 function FinalizeTimetable() {

--- a/frontend/src/pages/ViewTimetable.tsx
+++ b/frontend/src/pages/ViewTimetable.tsx
@@ -1,57 +1,30 @@
 import { Route } from "@tanstack/react-router";
 import { toPng } from "html-to-image";
-import { Menu } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import ReportIssue from "@/components/ReportIssue";
 import ReportIssueToastAction from "@/components/ReportIssueToastAction";
 import TimetableHeader from "@/components/TimetableHeader";
 import {
+  TimetablePageError,
+  TimetablePageShell,
+  timetablePageLoader,
+} from "@/components/TimetablePageShell";
+import {
   TimetableActionType,
   TimetableProvider,
   useTimetableState,
 } from "@/context";
-import {
-  handleLoginRedirect,
-  handleNotFound,
-} from "@/data-access/errors/handlers";
-import toastHandler from "@/data-access/errors/toastHandler";
-import { courseQueryOptions } from "@/data-access/hooks/useCourses";
-import { timetableQueryOptions } from "@/data-access/hooks/useTimetable";
-import { userQueryOptions } from "@/data-access/hooks/useUser";
 import authenticatedRoute from "../AuthenticatedRoute";
 import CenteredSpinner from "../components/CenteredSpinner";
 import NotFound from "../components/NotFound";
 import { SideMenu } from "../components/SideMenu";
-import Spinner from "../components/Spinner";
 import { TimetableGrid } from "../components/TimetableGrid";
-import { Button } from "../components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../components/ui/popover";
-import { TooltipProvider } from "../components/ui/tooltip";
-import { toast, useToast } from "../components/ui/use-toast";
+import { toast } from "../components/ui/use-toast";
 
 const viewTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,
   path: "view/$timetableId",
-  loader: async ({ context: { queryClient }, params: { timetableId } }) => {
-    queryClient.ensureQueryData(userQueryOptions);
-    // Courses are fetched for the semester of the timetable being viewed, so
-    // the timetable has to be loaded first. Awaiting both keeps this data in
-    // the loader, so preloading warms it before navigation (see
-    // https://tanstack.com/router/v1/docs/guide/data-loading)
-    const timetable = await queryClient.ensureQueryData(
-      timetableQueryOptions(timetableId),
-    );
-    await queryClient.ensureQueryData(
-      courseQueryOptions({
-        acadYear: timetable.acadYear,
-        semester: timetable.semester,
-      }),
-    );
-  },
+  loader: timetablePageLoader,
   pendingComponent: CenteredSpinner,
   component: () => (
     <TimetableProvider>
@@ -59,17 +32,12 @@ const viewTimetableRoute = new Route({
     </TimetableProvider>
   ),
   notFoundComponent: NotFound,
-  errorComponent: ({ error }) => {
-    const { toast } = useToast();
-    handleLoginRedirect(error);
-    handleNotFound(error);
-    toastHandler(error, toast);
-  },
+  errorComponent: TimetablePageError,
 });
 
 function ViewTimetable() {
   const {
-    state: { isLoading, isVertical, user, courses, timetable, screenIsLarge },
+    state: { isVertical, user, courses, timetable, screenIsLarge },
     dispatch,
   } = useTimetableState();
 
@@ -138,45 +106,24 @@ function ViewTimetable() {
   );
 
   return (
-    <>
-      {isLoading ? (
-        <div className="flex flex-col text-muted-foreground gap-8 xl:text-xl lg:text-lg md:text-md text-sm bg-background h-[calc(100dvh-5rem)] justify-center w-full items-center">
-          <Spinner />
-          <span>Please wait while we copy over your timetable...</span>
-        </div>
-      ) : (
-        <div className="grow h-[calc(100vh-12rem)]">
-          <TooltipProvider>
-            <TimetableHeader
-              isOnEditPage={false}
-              generateScreenshot={generateScreenshot}
-            />
-            {/* the bg-background here is necessary so the generated image has the background in it */}
-            <div
-              className="flex flex-row gap-4 bg-background h-full relative"
-              ref={screenshotContentRef}
-            >
-              {screenIsLarge ? (
-                SideBar
-              ) : (
-                <Popover>
-                  <PopoverTrigger className="absolute left-2 top-[-1rem]">
-                    <Button variant={"default"} className="rounded-full">
-                      <Menu />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent>{SideBar}</PopoverContent>
-                </Popover>
-              )}
-              <TimetableGrid
-                isVertical={screenIsLarge ? isVertical : true}
-                isOnEditPage={false}
-              />
-            </div>
-          </TooltipProvider>
-        </div>
-      )}
-    </>
+    <TimetablePageShell
+      header={
+        <TimetableHeader
+          isOnEditPage={false}
+          generateScreenshot={generateScreenshot}
+        />
+      }
+      sidebar={SideBar}
+      contentRef={screenshotContentRef}
+      // the bg-background here is necessary so the generated image has the background in it
+      contentClassName="bg-background"
+      popoverTriggerClassName="top-[-1rem]"
+    >
+      <TimetableGrid
+        isVertical={screenIsLarge ? isVertical : true}
+        isOnEditPage={false}
+      />
+    </TimetablePageShell>
   );
 }
 


### PR DESCRIPTION
EditTimetable and ViewTimetable were near-clones: same loader, same error component, same loading spinner, same small-screen popover wiring. The shared shell now lives in TimetablePageShell.tsx so each page keeps only what differs, with the view page styling differences preserved via optional props. FinalizeTimetable uses the shared error component too.

Build and biome pass; not clicked through in a browser.
