### PR TITLE
Split timetable header and side menu

### DIFF
--- a/frontend/src/components/CDCList.tsx
+++ b/frontend/src/components/CDCList.tsx
@@ -1,0 +1,105 @@
+import { ChevronRight } from "lucide-react";
+import { TimetableActionType, useTimetableState } from "@/context";
+import { Button } from "./ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+export const CDCList = () => {
+  const {
+    state: { cdcs },
+    dispatch,
+  } = useTimetableState();
+
+  return (
+    <>
+      {cdcs
+        .filter((course) => course.id !== null)
+        .map((nonOptionalCourses) => {
+          const course = nonOptionalCourses as {
+            id: string;
+            code: string;
+            name: string;
+          };
+          return (
+            <Button
+              variant={"secondary"}
+              onClick={() =>
+                dispatch({
+                  type: TimetableActionType.SetSelectedCourseAndSection,
+                  courseID: course.id,
+                  sectionType: null,
+                })
+              }
+              key={course.id}
+              className="rounded-none text-left py-8 bg-secondary dark:hover:bg-slate-700 hover:bg-slate-200"
+            >
+              <div className="flex justify-between w-full items-center">
+                <span>{`${course.code}: ${course.name}`}</span>
+                <ChevronRight />
+              </div>
+            </Button>
+          );
+        })}
+      {cdcs
+        .filter((course) => course.id === null && course.type === "optional")
+        .map((optionalCourses) => {
+          const courseOptions = optionalCourses as {
+            id: null;
+            options: {
+              id: string;
+              code: string;
+              name: string;
+            }[];
+          };
+          return (
+            <>
+              <div className="border-slate-300 dark:border-slate-600 border-t-2 w-full h-fit" />
+              {courseOptions.options
+                .map((course) => (
+                  // biome-ignore lint/a11y/noStaticElementInteractions: need to check if button works styling wise
+                  // biome-ignore lint/a11y/useKeyWithClickEvents: need to check if button works styling wise
+                  <div
+                    key={course.id}
+                    onClick={() =>
+                      dispatch({
+                        type: TimetableActionType.SetSelectedCourseAndSection,
+                        courseID: course.id,
+                        sectionType: null,
+                      })
+                    }
+                    className="px-4 dark:hover:bg-slate-700 hover:bg-slate-200 transition duration-200 ease-in-out cursor-pointer h-14 border-slate-300 dark:border-slate-600 items-center flex justify-between"
+                  >
+                    <span className="w-fit text-sm">
+                      {course.code}: {course.name}
+                    </span>
+                    <ChevronRight className="w-6 h-6" />
+                  </div>
+                ))
+                .reduce((prev, curr) => (
+                  <>
+                    <div className="flex flex-col">
+                      {prev}
+                      <div className="w-full flex justify-center font-bold text-lg">
+                        <Tooltip delayDuration={100}>
+                          <TooltipTrigger asChild>
+                            <div className="border-2 flex justify-center items-center border-slate-300 dark:border-slate-600 text-secondary-foreground p-1 w-12 h-8 rounded-full z-20 text-center">
+                              OR
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent className="bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-sm">
+                            You have to pick only one of these options
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      {curr}
+                    </div>
+                  </>
+                ))}
+              <div className="border-slate-300 dark:border-slate-600 border-t-2 w-full h-fit" />
+            </>
+          );
+        })}
+    </>
+  );
+};
+
+export default CDCList;

--- a/frontend/src/components/CDCWarningsTooltip.tsx
+++ b/frontend/src/components/CDCWarningsTooltip.tsx
@@ -1,0 +1,159 @@
+import { AlertOctagon, ArrowUpRightFromCircle } from "lucide-react";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { TimetableActionType, useTimetableState } from "@/context";
+
+export const CDCWarningsTooltip = () => {
+  const {
+    state: { cdcs, coursesInTimetable },
+    dispatch,
+  } = useTimetableState();
+
+  const cdcNotFoundWarning = useMemo(
+    () =>
+      cdcs.filter((e) => e.id === null && e.type === "warning") as {
+        id: null;
+        type: "warning";
+        warning: string;
+      }[],
+    [cdcs],
+  );
+
+  const missingCDCs = useMemo(() => {
+    const missing: {
+      id: string;
+      code: string;
+      name: string;
+    }[] = [];
+    for (let i = 0; i < cdcs.length; i++) {
+      if (cdcs[i].id === null) {
+        const option = cdcs[i] as
+          | {
+              id: null;
+              type: "warning";
+              warning: string;
+            }
+          | {
+              id: null;
+              type: "optional";
+              options: {
+                id: string;
+                code: string;
+                name: string;
+              }[];
+            };
+        if (
+          option.type === "optional" &&
+          !option.options.some((e) =>
+            coursesInTimetable
+              .map((added) => added.id)
+              .includes(e.id as string),
+          )
+        ) {
+          const splitCodes = option.options.map((e) => e.code).join(" (or) ");
+          missing.push({
+            id: "",
+            code: splitCodes,
+            name: "",
+          });
+        }
+      } else {
+        if (
+          !coursesInTimetable.map((e) => e.id).includes(cdcs[i].id as string)
+        ) {
+          missing.push(
+            cdcs[i] as {
+              id: string;
+              code: string;
+              name: string;
+            },
+          );
+        }
+      }
+    }
+    return missing;
+  }, [coursesInTimetable, cdcs]);
+
+  const handleMissingCDCClick = (courseId: string) => {
+    dispatch({
+      type: TimetableActionType.SetMenuTab,
+      tab: "CDCs",
+    });
+    dispatch({
+      type: TimetableActionType.SetSelectedCourseAndSection,
+      courseID: courseId === "" ? null : courseId,
+      sectionType: null,
+    });
+  };
+
+  if (missingCDCs.length === 0 && cdcNotFoundWarning.length === 0) return null;
+
+  return (
+    <Tooltip delayDuration={100}>
+      <TooltipTrigger
+        asChild
+        className="hover:bg-accent hover:text-accent-foreground transition duration-200 ease-in-out"
+      >
+        <div className="p-2 rounded-full">
+          <AlertOctagon className="w-5 h-5 md:w-6 md:h-6 m-1" />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="bg-muted text-foreground border-muted-foreground/40 text-md">
+        {missingCDCs.length > 0 && (
+          <div className="flex flex-col">
+            <span>
+              You haven't added all CDCs for this semester to your timetable.
+            </span>
+            <span className="font-bold pt-2">CDCs missing:</span>
+            {missingCDCs.map((e) => (
+              <div className="flex items-center" key={e.id}>
+                <span className="ml-2">{e.code}</span>
+                <Button
+                  onClick={() => {
+                    handleMissingCDCClick(e.id);
+                  }}
+                  className="p-2 w-fit h-fit ml-2 mb-1 bg-transparent hover:bg-slate-300 dark:hover:bg-slate-700 text-secondary-foreground rounded-full"
+                >
+                  <ArrowUpRightFromCircle className="w-4 h-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+        {cdcNotFoundWarning.length > 0 && (
+          <div className="flex flex-col">
+            <span className="font-bold">
+              Chrono could not find some of your CDCs in the list of courses.
+            </span>
+            <span className="flex">
+              Please
+              <a
+                href="https://github.com/crux-bphc/chronofactorem-rewrite/issues"
+                className="text-blue-700 dark:text-blue-400 flex pl-1"
+              >
+                <span className="text-blue-700 dark:text-blue-400">
+                  report this issue
+                </span>
+                <ArrowUpRightFromCircle className="w-4 h-4 ml-1" />
+              </a>
+            </span>
+            <span className="font-bold pt-2">Error List:</span>
+
+            {cdcNotFoundWarning.map((e) => (
+              <span className="ml-2" key={e.id}>
+                {e.warning}
+              </span>
+            ))}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default CDCWarningsTooltip;

--- a/frontend/src/components/CourseSearchResults.tsx
+++ b/frontend/src/components/CourseSearchResults.tsx
@@ -1,0 +1,217 @@
+import { Bird, ChevronRight, HelpCircle } from "lucide-react";
+import { useMemo } from "react";
+import { TimetableActionType, useTimetableState } from "@/context";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+export const CourseSearchResults = ({
+  debouncedSearchTerm,
+}: {
+  debouncedSearchTerm: string;
+}) => {
+  const {
+    state: { courses, timetable },
+    dispatch,
+  } = useTimetableState();
+
+  const courseSearchResults = useMemo(() => {
+    if (courses === undefined || timetable === undefined) return [];
+    return (
+      debouncedSearchTerm === ""
+        ? courses
+        : courses.filter((e) =>
+            `${e.code}: ${e.name}`
+              .toLowerCase()
+              .includes(debouncedSearchTerm.toLowerCase()),
+          )
+    ).map((e) => {
+      const withClash = e as unknown as {
+        id: string;
+        code: string;
+        name: string;
+        midsemStartTime: string | null;
+        midsemEndTime: string | null;
+        compreStartTime: string | null;
+        compreEndTime: string | null;
+        clashing: null | string[];
+      };
+      if (e.midsemStartTime === null && e.compreStartTime === null) {
+        withClash.clashing = null;
+        return withClash;
+      }
+      if (e.midsemStartTime === null && e.compreStartTime !== null) {
+        const clashes = timetable.examTimes.filter((x) => {
+          if (x.split("|")[0] === e.code) return false;
+          return x.includes(
+            `${withClash.compreStartTime}|${withClash.compreEndTime}`,
+          );
+        });
+        withClash.clashing = clashes.length === 0 ? null : clashes;
+        return withClash;
+      }
+      if (e.midsemStartTime !== null && e.compreStartTime === null) {
+        const clashes = timetable.examTimes.filter((x) => {
+          if (x.split("|")[0] === e.code) return false;
+          return x.includes(
+            `${withClash.midsemStartTime}|${withClash.midsemEndTime}`,
+          );
+        });
+        withClash.clashing = clashes.length === 0 ? null : clashes;
+        return withClash;
+      }
+      const clashes = timetable.examTimes.filter((x) => {
+        if (x.split("|")[0] === e.code) return false;
+        return (
+          x.includes(
+            `${withClash.midsemStartTime}|${withClash.midsemEndTime}`,
+          ) ||
+          x.includes(`${withClash.compreStartTime}|${withClash.compreEndTime}`)
+        );
+      });
+      withClash.clashing = clashes.length === 0 ? null : clashes;
+      return withClash;
+    });
+  }, [courses, debouncedSearchTerm, timetable]);
+
+  return (
+    <div className="h-[calc(100%-3rem)] overflow-y-scroll">
+      {courseSearchResults.map((course) => (
+        // TODO - deal with this biome rule
+        // biome-ignore lint/a11y/useKeyWithClickEvents: bro come on really
+        // biome-ignore lint/a11y/noStaticElementInteractions: bro come on really
+        <div
+          onClick={() => {
+            if (!course.clashing) {
+              dispatch({
+                type: TimetableActionType.SetSelectedCourseAndSection,
+                courseID: course.id,
+                sectionType: null,
+              });
+            }
+          }}
+          key={course.id}
+          className={`relative px-4 transition flex-col pt-4 flex duration-200 ease-in-out border-t-2 border-muted-foreground/20 ${
+            course.clashing
+              ? "text-muted-foreground"
+              : "cursor-pointer bg-secondary dark:hover:bg-slate-700 hover:bg-slate-200"
+          }`}
+        >
+          {course.clashing && (
+            <div className="absolute left-0 top-8 py-1 dark:bg-slate-700/80 bg-slate-300/80 text-secondary-foreground text-center w-full">
+              <span className="font-medium text-md">
+                Clashing with{" "}
+                {course.clashing
+                  .map((x) => {
+                    const [code, exam] = x.split("|");
+                    return `${code}'s ${exam.toLowerCase()}`;
+                  })
+                  .join(", ")}
+              </span>
+            </div>
+          )}
+
+          <div className="w-full flex justify-between items-center">
+            <span className="w-fit text-sm">
+              {course.code}: {course.name}
+            </span>
+            <ChevronRight className="w-6 h-6" />
+          </div>
+
+          <div>
+            <span className="pl-4 py-1 text-sm font-bold">Midsem</span>
+            <span className="pl-4 py-1 text-sm">
+              {`${
+                course.midsemStartTime
+                  ? new Date(course.midsemStartTime).toLocaleDateString(
+                      "en-US",
+                      {
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "numeric",
+                        hour12: true,
+                      },
+                    )
+                  : "N/A"
+              } — ${
+                course.midsemEndTime
+                  ? new Date(course.midsemEndTime).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      hour: "numeric",
+                      minute: "numeric",
+                      hour12: true,
+                    })
+                  : "N/A"
+              }`}
+              {course.midsemStartTime === null && (
+                <Tooltip delayDuration={100}>
+                  <TooltipTrigger asChild>
+                    <div className="inline bg-transparent w-fit rounded-full dark:hover:bg-slate-800/80 text-secondary-foreground hover:bg-slate-300/80 p-1 transition duration-200 ease-in-out ml-2 text-sm font-bold">
+                      <HelpCircle className="inline h-4 w-4" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent className="w-96 bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-md">
+                    Timetable Division hasn't published the midsem dates for
+                    this course. Either there is no midsem exam, or they haven't
+                    decided it yet. We recommend checking with your professor.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </span>
+          </div>
+          <div className="pb-4">
+            <span className="pl-4 py-1 text-sm font-bold">Compre</span>
+            <span className="pl-4 py-1 text-sm">
+              {`${
+                course.compreStartTime
+                  ? new Date(course.compreStartTime).toLocaleDateString(
+                      "en-US",
+                      {
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "numeric",
+                        hour12: true,
+                      },
+                    )
+                  : "N/A"
+              } — ${
+                course.compreEndTime
+                  ? new Date(course.compreEndTime).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      hour: "numeric",
+                      minute: "numeric",
+                      hour12: true,
+                    })
+                  : "N/A"
+              }`}
+              {course.compreStartTime === null && (
+                <Tooltip delayDuration={100}>
+                  <TooltipTrigger asChild>
+                    <div className="inline bg-transparent w-fit rounded-full dark:hover:bg-slate-800/80 text-secondary-foreground hover:bg-slate-300/80 p-1 transition duration-200 ease-in-out ml-2 text-sm font-bold">
+                      <HelpCircle className="inline h-4 w-4" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent className="w-96 bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-md">
+                    Timetable Division hasn't published the compre dates for
+                    this course. Either there is no compre exam, or they haven't
+                    decided it yet. We recommend checking with your professor.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </span>
+          </div>
+        </div>
+      ))}
+      {courseSearchResults.length === 0 && (
+        <div className="flex flex-col justify-center pt-4 items-center bg-secondary h-full rounded-xl">
+          <Bird className="text-muted-foreground w-36 h-36 mb-4" />
+          <span className="text-muted-foreground text-2xl">No results</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CourseSearchResults;

--- a/frontend/src/components/DeleteTimetableDialog.tsx
+++ b/frontend/src/components/DeleteTimetableDialog.tsx
@@ -1,0 +1,76 @@
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import type React from "react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import useDeleteTimetable from "@/data-access/hooks/useDeleteTimetable";
+
+export const DeleteTimetableDialog = ({
+  timetableId,
+  onDeleted,
+  children,
+}: {
+  timetableId: string;
+  onDeleted?: () => void;
+  children: React.ReactNode;
+}) => {
+  const { mutate: deleteTimetable } = useDeleteTimetable();
+
+  return (
+    <AlertDialog>
+      <Tooltip>
+        <AlertDialogTrigger asChild>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              className="rounded-full p-3 hover:bg-destructive/90 hover:text-destructive-foreground"
+            >
+              {children}
+            </Button>
+          </TooltipTrigger>
+        </AlertDialogTrigger>
+        <TooltipContent>
+          <p>Delete Timetable</p>
+        </TooltipContent>
+      </Tooltip>
+      <AlertDialogContent className="p-8">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-2xl">
+            Are you sure?
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-destructive text-lg font-bold">
+            All your progress on this timetable will be lost, and unrecoverable.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogPrimitive.Action asChild>
+            <Button
+              variant="destructive"
+              onClick={() =>
+                deleteTimetable(timetableId, { onSuccess: onDeleted })
+              }
+            >
+              Delete
+            </Button>
+          </AlertDialogPrimitive.Action>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default DeleteTimetableDialog;

--- a/frontend/src/components/SideMenu.tsx
+++ b/frontend/src/components/SideMenu.tsx
@@ -1,14 +1,13 @@
-import { Bird, ChevronRight, HelpCircle } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
-import { TimetableActionType, useTimetableState } from "@/context";
+import { useTimetableState } from "@/context";
+import CDCList from "./CDCList";
+import CourseSearchResults from "./CourseSearchResults";
 import EditCoursesTab from "./EditCoursesTab";
 import ExamTab from "./ExamTab";
 import SideMenuTabs from "./SideMenuTabs";
-import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Tabs, TabsContent } from "./ui/tabs";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import ViewCoursesTab from "./ViewCoursesTab";
 
 export function SideMenu({
@@ -20,69 +19,9 @@ export function SideMenu({
 }) {
   const [searchTerm, setSearchTerm] = useState("");
   const {
-    state: { courses, timetable, cdcs, currentTab },
-    dispatch,
+    state: { timetable, currentTab },
   } = useTimetableState();
   const [debouncedSearchTerm, _] = useDebounceValue<string>(searchTerm, 500);
-
-  const courseSearchResults = useMemo(() => {
-    if (courses === undefined || timetable === undefined) return [];
-    return (
-      debouncedSearchTerm === ""
-        ? courses
-        : courses.filter((e) =>
-            `${e.code}: ${e.name}`
-              .toLowerCase()
-              .includes(debouncedSearchTerm.toLowerCase()),
-          )
-    ).map((e) => {
-      const withClash = e as unknown as {
-        id: string;
-        code: string;
-        name: string;
-        midsemStartTime: string | null;
-        midsemEndTime: string | null;
-        compreStartTime: string | null;
-        compreEndTime: string | null;
-        clashing: null | string[];
-      };
-      if (e.midsemStartTime === null && e.compreStartTime === null) {
-        withClash.clashing = null;
-        return withClash;
-      }
-      if (e.midsemStartTime === null && e.compreStartTime !== null) {
-        const clashes = timetable.examTimes.filter((x) => {
-          if (x.split("|")[0] === e.code) return false;
-          return x.includes(
-            `${withClash.compreStartTime}|${withClash.compreEndTime}`,
-          );
-        });
-        withClash.clashing = clashes.length === 0 ? null : clashes;
-        return withClash;
-      }
-      if (e.midsemStartTime !== null && e.compreStartTime === null) {
-        const clashes = timetable.examTimes.filter((x) => {
-          if (x.split("|")[0] === e.code) return false;
-          return x.includes(
-            `${withClash.midsemStartTime}|${withClash.midsemEndTime}`,
-          );
-        });
-        withClash.clashing = clashes.length === 0 ? null : clashes;
-        return withClash;
-      }
-      const clashes = timetable.examTimes.filter((x) => {
-        if (x.split("|")[0] === e.code) return false;
-        return (
-          x.includes(
-            `${withClash.midsemStartTime}|${withClash.midsemEndTime}`,
-          ) ||
-          x.includes(`${withClash.compreStartTime}|${withClash.compreEndTime}`)
-        );
-      });
-      withClash.clashing = clashes.length === 0 ? null : clashes;
-      return withClash;
-    });
-  }, [courses, debouncedSearchTerm, timetable]);
 
   if (timetable === undefined) return;
 
@@ -98,95 +37,7 @@ export function SideMenu({
           value="CDCs"
           className="border-muted-foreground/80 w-[26rem] data-[state=inactive]:h-0 flex flex-col h-full overflow-y-scroll"
         >
-          {cdcs
-            .filter((course) => course.id !== null)
-            .map((nonOptionalCourses) => {
-              const course = nonOptionalCourses as {
-                id: string;
-                code: string;
-                name: string;
-              };
-              return (
-                <Button
-                  variant={"secondary"}
-                  onClick={() =>
-                    dispatch({
-                      type: TimetableActionType.SetSelectedCourseAndSection,
-                      courseID: course.id,
-                      sectionType: null,
-                    })
-                  }
-                  key={course.id}
-                  className="rounded-none text-left py-8 bg-secondary dark:hover:bg-slate-700 hover:bg-slate-200"
-                >
-                  <div className="flex justify-between w-full items-center">
-                    <span>{`${course.code}: ${course.name}`}</span>
-                    <ChevronRight />
-                  </div>
-                </Button>
-              );
-            })}
-          {cdcs
-            .filter(
-              (course) => course.id === null && course.type === "optional",
-            )
-            .map((optionalCourses) => {
-              const courseOptions = optionalCourses as {
-                id: null;
-                options: {
-                  id: string;
-                  code: string;
-                  name: string;
-                }[];
-              };
-              return (
-                <>
-                  <div className="border-slate-300 dark:border-slate-600 border-t-2 w-full h-fit" />
-                  {courseOptions.options
-                    .map((course) => (
-                      // biome-ignore lint/a11y/noStaticElementInteractions: need to check if button works styling wise
-                      // biome-ignore lint/a11y/useKeyWithClickEvents: need to check if button works styling wise
-                      <div
-                        key={course.id}
-                        onClick={() =>
-                          dispatch({
-                            type: TimetableActionType.SetSelectedCourseAndSection,
-                            courseID: course.id,
-                            sectionType: null,
-                          })
-                        }
-                        className="px-4 dark:hover:bg-slate-700 hover:bg-slate-200 transition duration-200 ease-in-out cursor-pointer h-14 border-slate-300 dark:border-slate-600 items-center flex justify-between"
-                      >
-                        <span className="w-fit text-sm">
-                          {course.code}: {course.name}
-                        </span>
-                        <ChevronRight className="w-6 h-6" />
-                      </div>
-                    ))
-                    .reduce((prev, curr) => (
-                      <>
-                        <div className="flex flex-col">
-                          {prev}
-                          <div className="w-full flex justify-center font-bold text-lg">
-                            <Tooltip delayDuration={100}>
-                              <TooltipTrigger asChild>
-                                <div className="border-2 flex justify-center items-center border-slate-300 dark:border-slate-600 text-secondary-foreground p-1 w-12 h-8 rounded-full z-20 text-center">
-                                  OR
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent className="bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-sm">
-                                You have to pick only one of these options
-                              </TooltipContent>
-                            </Tooltip>
-                          </div>
-                          {curr}
-                        </div>
-                      </>
-                    ))}
-                  <div className="border-slate-300 dark:border-slate-600 border-t-2 w-full h-fit" />
-                </>
-              );
-            })}
+          <CDCList />
         </TabsContent>
 
         {isOnEditPage ? <EditCoursesTab /> : <ViewCoursesTab />}
@@ -205,154 +56,7 @@ export function SideMenu({
             />
           </div>
 
-          <div className="h-[calc(100%-3rem)] overflow-y-scroll">
-            {courseSearchResults.map((course) => (
-              // TODO - deal with this biome rule
-              // biome-ignore lint/a11y/useKeyWithClickEvents: bro come on really
-              // biome-ignore lint/a11y/noStaticElementInteractions: bro come on really
-              <div
-                onClick={() => {
-                  if (!course.clashing) {
-                    dispatch({
-                      type: TimetableActionType.SetSelectedCourseAndSection,
-                      courseID: course.id,
-                      sectionType: null,
-                    });
-                  }
-                }}
-                key={course.id}
-                className={`relative px-4 transition flex-col pt-4 flex duration-200 ease-in-out border-t-2 border-muted-foreground/20 ${
-                  course.clashing
-                    ? "text-muted-foreground"
-                    : "cursor-pointer bg-secondary dark:hover:bg-slate-700 hover:bg-slate-200"
-                }`}
-              >
-                {course.clashing && (
-                  <div className="absolute left-0 top-8 py-1 dark:bg-slate-700/80 bg-slate-300/80 text-secondary-foreground text-center w-full">
-                    <span className="font-medium text-md">
-                      Clashing with{" "}
-                      {course.clashing
-                        .map((x) => {
-                          const [code, exam] = x.split("|");
-                          return `${code}'s ${exam.toLowerCase()}`;
-                        })
-                        .join(", ")}
-                    </span>
-                  </div>
-                )}
-
-                <div className="w-full flex justify-between items-center">
-                  <span className="w-fit text-sm">
-                    {course.code}: {course.name}
-                  </span>
-                  <ChevronRight className="w-6 h-6" />
-                </div>
-
-                <div>
-                  <span className="pl-4 py-1 text-sm font-bold">Midsem</span>
-                  <span className="pl-4 py-1 text-sm">
-                    {`${
-                      course.midsemStartTime
-                        ? new Date(course.midsemStartTime).toLocaleDateString(
-                            "en-US",
-                            {
-                              month: "short",
-                              day: "numeric",
-                              hour: "numeric",
-                              minute: "numeric",
-                              hour12: true,
-                            },
-                          )
-                        : "N/A"
-                    } — ${
-                      course.midsemEndTime
-                        ? new Date(course.midsemEndTime).toLocaleDateString(
-                            "en-US",
-                            {
-                              month: "short",
-                              day: "numeric",
-                              hour: "numeric",
-                              minute: "numeric",
-                              hour12: true,
-                            },
-                          )
-                        : "N/A"
-                    }`}
-                    {course.midsemStartTime === null && (
-                      <Tooltip delayDuration={100}>
-                        <TooltipTrigger asChild>
-                          <div className="inline bg-transparent w-fit rounded-full dark:hover:bg-slate-800/80 text-secondary-foreground hover:bg-slate-300/80 p-1 transition duration-200 ease-in-out ml-2 text-sm font-bold">
-                            <HelpCircle className="inline h-4 w-4" />
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent className="w-96 bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-md">
-                          Timetable Division hasn't published the midsem dates
-                          for this course. Either there is no midsem exam, or
-                          they haven't decided it yet. We recommend checking
-                          with your professor.
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </span>
-                </div>
-                <div className="pb-4">
-                  <span className="pl-4 py-1 text-sm font-bold">Compre</span>
-                  <span className="pl-4 py-1 text-sm">
-                    {`${
-                      course.compreStartTime
-                        ? new Date(course.compreStartTime).toLocaleDateString(
-                            "en-US",
-                            {
-                              month: "short",
-                              day: "numeric",
-                              hour: "numeric",
-                              minute: "numeric",
-                              hour12: true,
-                            },
-                          )
-                        : "N/A"
-                    } — ${
-                      course.compreEndTime
-                        ? new Date(course.compreEndTime).toLocaleDateString(
-                            "en-US",
-                            {
-                              month: "short",
-                              day: "numeric",
-                              hour: "numeric",
-                              minute: "numeric",
-                              hour12: true,
-                            },
-                          )
-                        : "N/A"
-                    }`}
-                    {course.compreStartTime === null && (
-                      <Tooltip delayDuration={100}>
-                        <TooltipTrigger asChild>
-                          <div className="inline bg-transparent w-fit rounded-full dark:hover:bg-slate-800/80 text-secondary-foreground hover:bg-slate-300/80 p-1 transition duration-200 ease-in-out ml-2 text-sm font-bold">
-                            <HelpCircle className="inline h-4 w-4" />
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent className="w-96 bg-secondary text-secondary-foreground border-slate-300 dark:border-slate-600 text-md">
-                          Timetable Division hasn't published the compre dates
-                          for this course. Either there is no compre exam, or
-                          they haven't decided it yet. We recommend checking
-                          with your professor.
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </span>
-                </div>
-              </div>
-            ))}
-            {courseSearchResults.length === 0 && (
-              <div className="flex flex-col justify-center pt-4 items-center bg-secondary h-full rounded-xl">
-                <Bird className="text-muted-foreground w-36 h-36 mb-4" />
-                <span className="text-muted-foreground text-2xl">
-                  No results
-                </span>
-              </div>
-            )}
-          </div>
+          <CourseSearchResults debouncedSearchTerm={debouncedSearchTerm} />
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/components/TimetableCard.tsx
+++ b/frontend/src/components/TimetableCard.tsx
@@ -1,19 +1,9 @@
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import { Link } from "@tanstack/react-router";
 import type { timetableType } from "lib";
 import { Edit2, Eye, EyeOff, Trash } from "lucide-react";
 import { useState } from "react";
 import type { z } from "zod";
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import DeleteTimetableDialog from "@/components/DeleteTimetableDialog";
 import {
   Dialog,
   DialogClose,
@@ -25,13 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import useDeleteTimetable from "@/data-access/hooks/useDeleteTimetable";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import useEditTimetable from "@/data-access/hooks/useEditTimetable";
 import { router } from "../main";
 import { Badge } from "./ui/badge";
@@ -56,7 +40,6 @@ function TimetableCard({ timetable, showFooter }: Props) {
     null | boolean
   >(null);
 
-  const { mutate: deleteTimetable } = useDeleteTimetable();
   const { mutate: editTimetable } = useEditTimetable();
 
   return (
@@ -196,45 +179,9 @@ function TimetableCard({ timetable, showFooter }: Props) {
               </Button>
             )}
 
-            <AlertDialog>
-              <Tooltip>
-                <AlertDialogTrigger asChild>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      className="rounded-full p-3 hover:bg-destructive/90 hover:text-destructive-foreground"
-                    >
-                      <Trash />
-                    </Button>
-                  </TooltipTrigger>
-                </AlertDialogTrigger>
-                <TooltipContent>
-                  <p>Delete Timetable</p>
-                </TooltipContent>
-              </Tooltip>
-              <AlertDialogContent className="p-8">
-                <AlertDialogHeader>
-                  <AlertDialogTitle className="text-2xl">
-                    Are you sure?
-                  </AlertDialogTitle>
-                  <AlertDialogDescription className="text-destructive text-lg font-bold">
-                    All your progress on this timetable will be lost, and
-                    unrecoverable.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogPrimitive.Action asChild>
-                    <Button
-                      variant="destructive"
-                      onClick={() => deleteTimetable(timetable.id)}
-                    >
-                      Delete
-                    </Button>
-                  </AlertDialogPrimitive.Action>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <DeleteTimetableDialog timetableId={timetable.id}>
+              <Trash />
+            </DeleteTimetableDialog>
           </CardFooter>
         )}
       </Card>

--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -1,8 +1,4 @@
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import {
-  AlertOctagon,
-  AlertTriangle,
-  ArrowUpRightFromCircle,
   Copy,
   Download,
   Edit2,
@@ -11,7 +7,9 @@ import {
   Send,
   Trash,
 } from "lucide-react";
-import { useMemo } from "react";
+import CDCWarningsTooltip from "@/components/CDCWarningsTooltip";
+import DeleteTimetableDialog from "@/components/DeleteTimetableDialog";
+import TimetableWarningsTooltip from "@/components/TimetableWarningsTooltip";
 import {
   Tooltip,
   TooltipContent,
@@ -19,18 +17,7 @@ import {
 } from "@/components/ui/tooltip";
 import { TimetableActionType, useTimetableState } from "@/context";
 import useCopyTimetable from "@/data-access/hooks/useCopyTimetable";
-import useDeleteTimetable from "@/data-access/hooks/useDeleteTimetable";
 import useEditTimetable from "@/data-access/hooks/useEditTimetable";
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "../components/ui/alert-dialog";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { router } from "../main";
@@ -43,97 +30,11 @@ const TimetableHeader = ({
   generateScreenshot: () => void;
 }) => {
   const {
-    state: {
-      isVertical,
-      user,
-      courses,
-      timetable,
-      coursesInTimetable,
-      cdcs,
-      screenIsLarge,
-    },
+    state: { isVertical, user, courses, timetable, screenIsLarge },
     dispatch,
   } = useTimetableState();
-  const { mutate: deleteTimetable } = useDeleteTimetable();
   const { mutate: editTimetable } = useEditTimetable();
   const { mutate: copyTimetable } = useCopyTimetable();
-
-  const cdcNotFoundWarning = useMemo(
-    () =>
-      cdcs.filter((e) => e.id === null && e.type === "warning") as {
-        id: null;
-        type: "warning";
-        warning: string;
-      }[],
-    [cdcs],
-  );
-
-  const missingCDCs = useMemo(() => {
-    const missing: {
-      id: string;
-      code: string;
-      name: string;
-    }[] = [];
-    for (let i = 0; i < cdcs.length; i++) {
-      if (cdcs[i].id === null) {
-        const option = cdcs[i] as
-          | {
-              id: null;
-              type: "warning";
-              warning: string;
-            }
-          | {
-              id: null;
-              type: "optional";
-              options: {
-                id: string;
-                code: string;
-                name: string;
-              }[];
-            };
-        if (
-          option.type === "optional" &&
-          !option.options.some((e) =>
-            coursesInTimetable
-              .map((added) => added.id)
-              .includes(e.id as string),
-          )
-        ) {
-          const splitCodes = option.options.map((e) => e.code).join(" (or) ");
-          missing.push({
-            id: "",
-            code: splitCodes,
-            name: "",
-          });
-        }
-      } else {
-        if (
-          !coursesInTimetable.map((e) => e.id).includes(cdcs[i].id as string)
-        ) {
-          missing.push(
-            cdcs[i] as {
-              id: string;
-              code: string;
-              name: string;
-            },
-          );
-        }
-      }
-    }
-    return missing;
-  }, [coursesInTimetable, cdcs]);
-
-  const handleMissingCDCClick = (courseId: string) => {
-    dispatch({
-      type: TimetableActionType.SetMenuTab,
-      tab: "CDCs",
-    });
-    dispatch({
-      type: TimetableActionType.SetSelectedCourseAndSection,
-      courseID: courseId === "" ? null : courseId,
-      sectionType: null,
-    });
-  };
 
   if (timetable === undefined || user === undefined || courses === undefined)
     return;
@@ -164,69 +65,7 @@ const TimetableHeader = ({
       </span>
       <span className="flex justify-center items-center gap-2">
         {isOnEditPage ? (
-          (missingCDCs.length > 0 || cdcNotFoundWarning.length > 0) && (
-            <Tooltip delayDuration={100}>
-              <TooltipTrigger
-                asChild
-                className="hover:bg-accent hover:text-accent-foreground transition duration-200 ease-in-out"
-              >
-                <div className="p-2 rounded-full">
-                  <AlertOctagon className="w-5 h-5 md:w-6 md:h-6 m-1" />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent className="bg-muted text-foreground border-muted-foreground/40 text-md">
-                {missingCDCs.length > 0 && (
-                  <div className="flex flex-col">
-                    <span>
-                      You haven't added all CDCs for this semester to your
-                      timetable.
-                    </span>
-                    <span className="font-bold pt-2">CDCs missing:</span>
-                    {missingCDCs.map((e) => (
-                      <div className="flex items-center" key={e.id}>
-                        <span className="ml-2">{e.code}</span>
-                        <Button
-                          onClick={() => {
-                            handleMissingCDCClick(e.id);
-                          }}
-                          className="p-2 w-fit h-fit ml-2 mb-1 bg-transparent hover:bg-slate-300 dark:hover:bg-slate-700 text-secondary-foreground rounded-full"
-                        >
-                          <ArrowUpRightFromCircle className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {cdcNotFoundWarning.length > 0 && (
-                  <div className="flex flex-col">
-                    <span className="font-bold">
-                      Chrono could not find some of your CDCs in the list of
-                      courses.
-                    </span>
-                    <span className="flex">
-                      Please
-                      <a
-                        href="https://github.com/crux-bphc/chronofactorem-rewrite/issues"
-                        className="text-blue-700 dark:text-blue-400 flex pl-1"
-                      >
-                        <span className="text-blue-700 dark:text-blue-400">
-                          report this issue
-                        </span>
-                        <ArrowUpRightFromCircle className="w-4 h-4 ml-1" />
-                      </a>
-                    </span>
-                    <span className="font-bold pt-2">Error List:</span>
-
-                    {cdcNotFoundWarning.map((e) => (
-                      <span className="ml-2" key={e.id}>
-                        {e.warning}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </TooltipContent>
-            </Tooltip>
-          )
+          <CDCWarningsTooltip />
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -346,111 +185,15 @@ const TimetableHeader = ({
           </TooltipContent>
         </Tooltip>
         {user.id === timetable.authorId && (
-          <AlertDialog>
-            <Tooltip>
-              <AlertDialogTrigger asChild>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="rounded-full p-3 hover:bg-destructive/90 hover:text-destructive-foreground"
-                  >
-                    <Trash className="w-5 h-5 md:w-6 md:h-6" />
-                  </Button>
-                </TooltipTrigger>
-              </AlertDialogTrigger>
-              <TooltipContent>
-                <p>Delete Timetable</p>
-              </TooltipContent>
-            </Tooltip>
-            <AlertDialogContent className="p-8">
-              <AlertDialogHeader>
-                <AlertDialogTitle className="text-2xl">
-                  Are you sure?
-                </AlertDialogTitle>
-                <AlertDialogDescription className="text-destructive text-lg font-bold">
-                  All your progress on this timetable will be lost, and
-                  unrecoverable.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogPrimitive.Action asChild>
-                  <Button
-                    variant="destructive"
-                    onClick={() =>
-                      deleteTimetable(timetable.id, {
-                        onSuccess: () => router.navigate({ to: "/" }),
-                      })
-                    }
-                  >
-                    Delete
-                  </Button>
-                </AlertDialogPrimitive.Action>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <DeleteTimetableDialog
+            timetableId={timetable.id}
+            onDeleted={() => router.navigate({ to: "/" })}
+          >
+            <Trash className="w-5 h-5 md:w-6 md:h-6" />
+          </DeleteTimetableDialog>
         )}
 
-        {timetable.warnings.length !== 0 && (
-          <Tooltip delayDuration={100}>
-            <TooltipTrigger
-              asChild
-              className="duration-200 mr-4 text-md p-2 h-fit dark:dark:hover:bg-orange-800/40 hover:bg-orange-300/40 rounded-lg px-4"
-            >
-              <div className="flex items-center">
-                <span className="text-orange-600 dark:text-orange-400 pr-4">
-                  {timetable.warnings
-                    .slice(0, 2)
-                    .map((x) => x.replace(":", " "))
-                    .map((x, i) => (
-                      <div key={x}>
-                        <span className="font-bold">{x}</span>
-                        {i >= 0 && i < timetable.warnings.length - 1 && (
-                          <span>, </span>
-                        )}
-                      </div>
-                    ))}
-                  {timetable.warnings.length > 2 &&
-                    ` and ${timetable.warnings.length - 2} other warning${
-                      timetable.warnings.length > 3 ? "s" : ""
-                    }`}
-                </span>
-                <AlertTriangle className="w-6 h-6 m-1 text-orange-600 dark:text-orange-400" />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent className="bg-muted text-foreground border-muted-foreground/40 text-md">
-              {timetable.warnings.map((warning) => (
-                <div className="pb-2" key={warning}>
-                  <span className="font-bold">{warning.split(":")[0]} is</span>
-                  <div className="flex flex-col pl-4">
-                    {warning
-                      .split(":")[1]
-                      .split("")
-                      .map((x) => (
-                        <div className="flex items-center" key={x}>
-                          <span>missing a {x} section</span>
-                          <Button
-                            onClick={() => {
-                              dispatch({
-                                type: TimetableActionType.SetSelectedCourseAndSection,
-                                courseID: courses.filter(
-                                  (x) => x.code === warning.split(":")[0],
-                                )[0].id,
-                                sectionType: x as "L" | "P" | "T",
-                              });
-                            }}
-                            className="p-2 w-fit h-fit ml-2 mb-1 bg-transparent hover:bg-slate-300 dark:hover:bg-muted-foreground/30 text-secondary-foreground rounded-full"
-                          >
-                            <ArrowUpRightFromCircle className="w-4 h-4 text-foreground" />
-                          </Button>
-                        </div>
-                      ))}
-                  </div>
-                </div>
-              ))}
-            </TooltipContent>
-          </Tooltip>
-        )}
+        <TimetableWarningsTooltip />
 
         {isOnEditPage && (
           <Tooltip delayDuration={100}>

--- a/frontend/src/components/TimetableWarningsTooltip.tsx
+++ b/frontend/src/components/TimetableWarningsTooltip.tsx
@@ -1,0 +1,86 @@
+import { AlertTriangle, ArrowUpRightFromCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { TimetableActionType, useTimetableState } from "@/context";
+
+export const TimetableWarningsTooltip = () => {
+  const {
+    state: { courses, timetable },
+    dispatch,
+  } = useTimetableState();
+
+  if (
+    courses === undefined ||
+    timetable === undefined ||
+    timetable.warnings.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <Tooltip delayDuration={100}>
+      <TooltipTrigger
+        asChild
+        className="duration-200 mr-4 text-md p-2 h-fit dark:dark:hover:bg-orange-800/40 hover:bg-orange-300/40 rounded-lg px-4"
+      >
+        <div className="flex items-center">
+          <span className="text-orange-600 dark:text-orange-400 pr-4">
+            {timetable.warnings
+              .slice(0, 2)
+              .map((x) => x.replace(":", " "))
+              .map((x, i) => (
+                <div key={x}>
+                  <span className="font-bold">{x}</span>
+                  {i >= 0 && i < timetable.warnings.length - 1 && (
+                    <span>, </span>
+                  )}
+                </div>
+              ))}
+            {timetable.warnings.length > 2 &&
+              ` and ${timetable.warnings.length - 2} other warning${
+                timetable.warnings.length > 3 ? "s" : ""
+              }`}
+          </span>
+          <AlertTriangle className="w-6 h-6 m-1 text-orange-600 dark:text-orange-400" />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="bg-muted text-foreground border-muted-foreground/40 text-md">
+        {timetable.warnings.map((warning) => (
+          <div className="pb-2" key={warning}>
+            <span className="font-bold">{warning.split(":")[0]} is</span>
+            <div className="flex flex-col pl-4">
+              {warning
+                .split(":")[1]
+                .split("")
+                .map((x) => (
+                  <div className="flex items-center" key={x}>
+                    <span>missing a {x} section</span>
+                    <Button
+                      onClick={() => {
+                        dispatch({
+                          type: TimetableActionType.SetSelectedCourseAndSection,
+                          courseID: courses.filter(
+                            (x) => x.code === warning.split(":")[0],
+                          )[0].id,
+                          sectionType: x as "L" | "P" | "T",
+                        });
+                      }}
+                      className="p-2 w-fit h-fit ml-2 mb-1 bg-transparent hover:bg-slate-300 dark:hover:bg-muted-foreground/30 text-secondary-foreground rounded-full"
+                    >
+                      <ArrowUpRightFromCircle className="w-4 h-4 text-foreground" />
+                    </Button>
+                  </div>
+                ))}
+            </div>
+          </div>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default TimetableWarningsTooltip;


### PR DESCRIPTION
Splits the two biggest components: TimetableHeader (483 to 226 lines) loses its two warning tooltips and delete dialog, and SideMenu (360 to 64 lines) loses the search results and CDC list. TimetableCard now shares the extracted DeleteTimetableDialog instead of carrying a near-verbatim copy. The remaining header bulk is the toolbar buttons, left as is.

Build and biome pass; visual check in a browser not done.
