### PR TITLE
Extract router setup out of main.tsx

### DIFF
--- a/frontend/src/AuthenticatedRoute.tsx
+++ b/frontend/src/AuthenticatedRoute.tsx
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 import { z } from "zod";
 import { NavBar } from "./components/Navbar";
 import chronoAPI from "./data-access/axios";
-import { rootRoute } from "./main";
+import { rootRoute } from "./router";
 
 const userAuthStatusType = z.object({
   message: z.string(),

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import useCreateTimetable from "@/data-access/hooks/useCreateTimetable";
 import useUser from "@/data-access/hooks/useUser";
-import { router } from "../main";
+import { router } from "../router";
 import Announcements from "./Announcements";
 import { ModeToggle } from "./ModeToggle";
 import ReportIssue from "./ReportIssue";

--- a/frontend/src/components/TimetableCard.tsx
+++ b/frontend/src/components/TimetableCard.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import useEditTimetable from "@/data-access/hooks/useEditTimetable";
-import { router } from "../main";
+import { router } from "../router";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import {

--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -20,7 +20,7 @@ import useCopyTimetable from "@/data-access/hooks/useCopyTimetable";
 import useEditTimetable from "@/data-access/hooks/useEditTimetable";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
-import { router } from "../main";
+import { router } from "../router";
 
 const TimetableHeader = ({
   isOnEditPage,

--- a/frontend/src/data-access/errors/handlers.ts
+++ b/frontend/src/data-access/errors/handlers.ts
@@ -1,6 +1,6 @@
 import { notFound } from "@tanstack/react-router";
 import { AxiosError } from "axios";
-import { router } from "@/main";
+import { router } from "@/router";
 
 export const handleNotFound = (error: unknown) => {
   if (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,70 +1,11 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  Router,
-  RouterProvider,
-  rootRouteWithContext,
-} from "@tanstack/react-router";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
 import React from "react";
 import { CookiesProvider } from "react-cookie";
 import ReactDOM from "react-dom/client";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import authenticatedRoute from "./AuthenticatedRoute";
-import NotFound from "./components/NotFound";
-import aboutRoute from "./pages/About";
-import editTimetableRoute from "./pages/EditTimetable";
-import editUserProfileRoute from "./pages/EditUserProfile";
-import finalizeTimetableRoute from "./pages/FinalizeTimetable";
-import getDegreesRoute from "./pages/GetDegrees";
-import homeRoute from "./pages/Home";
-import loginRoute from "./pages/Login";
-import viewTimetableRoute from "./pages/ViewTimetable";
-import RootComponent from "./RootComponent";
 import "./index.css";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-    },
-  },
-});
-
-export const rootRoute = rootRouteWithContext<{
-  queryClient: QueryClient;
-}>()({
-  component: RootComponent,
-});
-
-const routeTree = rootRoute.addChildren([
-  loginRoute,
-  getDegreesRoute,
-  aboutRoute,
-  authenticatedRoute.addChildren([
-    homeRoute,
-    editUserProfileRoute,
-    editTimetableRoute,
-    finalizeTimetableRoute,
-    viewTimetableRoute,
-  ]),
-]);
-
-export const router = new Router({
-  routeTree,
-  // Since we're using React Query, we don't want loader calls to ever be stale
-  // This will ensure that the loader is always called when the route is preloaded or visited
-  defaultPreloadStaleTime: 0,
-  context: {
-    queryClient,
-  },
-  defaultNotFoundComponent: NotFound,
-});
-
-// Register things for typesafety
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: typeof router;
-  }
-}
+import { queryClient, router } from "./router";
 
 const rootElement = document.getElementById("root");
 

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import { Route } from "@tanstack/react-router";
 import { ArrowUpRightFromCircle } from "lucide-react";
-import { rootRoute } from "../main";
+import { rootRoute } from "../router";
 
 const aboutRoute = new Route({
   getParentRoute: () => rootRoute,

--- a/frontend/src/pages/EditTimetable.tsx
+++ b/frontend/src/pages/EditTimetable.tsx
@@ -32,7 +32,7 @@ import {
   PopoverTrigger,
 } from "../components/ui/popover";
 import { toast, useToast } from "../components/ui/use-toast";
-import { router } from "../main";
+import { router } from "../router";
 
 const editTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,

--- a/frontend/src/pages/EditUserProfile.tsx
+++ b/frontend/src/pages/EditUserProfile.tsx
@@ -10,7 +10,7 @@ import useEditUser from "@/data-access/hooks/useEditUser";
 import useUser, { userQueryOptions } from "@/data-access/hooks/useUser";
 import authenticatedRoute from "../AuthenticatedRoute";
 import { useToast } from "../components/ui/use-toast";
-import { router } from "../main";
+import { router } from "../router";
 
 const editUserProfileRoute = new Route({
   getParentRoute: () => authenticatedRoute,

--- a/frontend/src/pages/FinalizeTimetable.tsx
+++ b/frontend/src/pages/FinalizeTimetable.tsx
@@ -22,7 +22,7 @@ import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { useToast } from "../components/ui/use-toast";
-import { router } from "../main";
+import { router } from "../router";
 
 const finalizeTimetableRoute = new Route({
   getParentRoute: () => authenticatedRoute,

--- a/frontend/src/pages/GetDegrees.tsx
+++ b/frontend/src/pages/GetDegrees.tsx
@@ -9,7 +9,7 @@ import { useToast } from "@/components/ui/use-toast";
 import toastHandler from "@/data-access/errors/toastHandler";
 import useCreateUser from "@/data-access/hooks/useCreateUser";
 import { userQueryOptions } from "@/data-access/hooks/useUser";
-import { rootRoute, router } from "../main";
+import { rootRoute, router } from "../router";
 
 /*
 Although users are always redirected to /getDegrees after login, we don't want to show them the page if they've already filled it out.

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,7 +11,7 @@ import authenticatedRoute from "../AuthenticatedRoute";
 import TimetableCard from "../components/TimetableCard";
 import { Button } from "../components/ui/button";
 import { useToast } from "../components/ui/use-toast";
-import { router } from "../main";
+import { router } from "../router";
 
 type Timetable = z.infer<typeof timetableType>;
 const renderTimetableSection = (title: string, timetables: Timetable[]) => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,7 +6,7 @@ import { authStatusQueryOptions } from "@/data-access/hooks/useAuthStatus";
 import { ModeToggle } from "../components/ModeToggle";
 import { Button } from "../components/ui/button";
 import { useToast } from "../components/ui/use-toast";
-import { rootRoute, router } from "../main";
+import { rootRoute, router } from "../router";
 
 const loginRoute = new Route({
   getParentRoute: () => rootRoute,

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,58 @@
+import { QueryClient } from "@tanstack/react-query";
+import { Router, rootRouteWithContext } from "@tanstack/react-router";
+import authenticatedRoute from "./AuthenticatedRoute";
+import NotFound from "./components/NotFound";
+import aboutRoute from "./pages/About";
+import editTimetableRoute from "./pages/EditTimetable";
+import editUserProfileRoute from "./pages/EditUserProfile";
+import finalizeTimetableRoute from "./pages/FinalizeTimetable";
+import getDegreesRoute from "./pages/GetDegrees";
+import homeRoute from "./pages/Home";
+import loginRoute from "./pages/Login";
+import viewTimetableRoute from "./pages/ViewTimetable";
+import RootComponent from "./RootComponent";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export const rootRoute = rootRouteWithContext<{
+  queryClient: QueryClient;
+}>()({
+  component: RootComponent,
+});
+
+const routeTree = rootRoute.addChildren([
+  loginRoute,
+  getDegreesRoute,
+  aboutRoute,
+  authenticatedRoute.addChildren([
+    homeRoute,
+    editUserProfileRoute,
+    editTimetableRoute,
+    finalizeTimetableRoute,
+    viewTimetableRoute,
+  ]),
+]);
+
+export const router = new Router({
+  routeTree,
+  // Since we're using React Query, we don't want loader calls to ever be stale
+  // This will ensure that the loader is always called when the route is preloaded or visited
+  defaultPreloadStaleTime: 0,
+  context: {
+    queryClient,
+  },
+  defaultNotFoundComponent: NotFound,
+});
+
+// Register things for typesafety
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
main.tsx used to own the query client, root route, route tree and router while 12 files imported router or rootRoute back from it, a fragile cycle. Router setup now lives in src/router.tsx and main.tsx only renders. No behavior change.

Build and biome pass.
