### PR TITLE
Fix session JWT outliving the session cookie

### DIFF
--- a/backend/src/utils/authUtils.ts
+++ b/backend/src/utils/authUtils.ts
@@ -51,7 +51,8 @@ export const setAuthCookies = (
 export const signJWT = (data: object, maxAge: number) => {
   return jwt.sign(data, Buffer.from(env.JWT_PRIVATE_KEY, "base64"), {
     algorithm: "RS256",
-    expiresIn: maxAge,
+    // maxAge is in milliseconds, but jsonwebtoken reads expiresIn as seconds
+    expiresIn: Math.floor(maxAge / 1000),
   });
 };
 


### PR DESCRIPTION
`signJWT` passed `SESSION_MAX_AGE_MS` straight to jsonwebtoken's `expiresIn`, which reads numbers as seconds, so session JWTs lived ~1000 days while the session cookie lived 24h. Cookie `maxAge` is only client-enforced, so the JWT was the real expiry and a stolen cookie was replayable for years. Now converts to seconds. Sessions will actually expire at `SESSION_MAX_AGE_MS` (24h) as intended.

Verified by decoding a freshly signed token (lifetime now matches the cookie); biome and tsc clean. Not run through the full dev stack since master can't boot with the Logto-only `.env` until #278 merges.
