### PR TITLE
Extract shared session verification helper

### DIFF
--- a/backend/src/controllers/user/auth.ts
+++ b/backend/src/controllers/user/auth.ts
@@ -21,11 +21,11 @@ import {
 import {
   clearAuthCookies,
   clearPkceCookies,
+  getSessionFromCookies,
   hashFingerprint,
   setAuthCookies,
   setPkceCookies,
   signJWT,
-  verifyJWT,
 } from "../../utils/authUtils.js";
 
 // On any route, when checking if a user is logged in, check for the cookie
@@ -57,23 +57,11 @@ export async function manageAuthRedirect(req: Request, res: Response) {
 
     const authRedirect = client.buildAuthorizationUrl(config, parameters);
 
-    if (req.cookies.session && req.cookies.fingerprint) {
-      const sessionCookie = req.cookies.session;
-      const fingerprintCookie = req.cookies.fingerprint;
-
-      const sessionData = verifyJWT(sessionCookie);
-
-      if (
-        typeof sessionData === "string" ||
-        sessionData.fingerprintHash !== hashFingerprint(fingerprintCookie)
-      ) {
-        clearAuthCookies(res);
-        setPkceCookies(res, code_verifier, state);
-        return res.redirect(authRedirect.href);
-      }
-
+    // a valid session means the user is already logged in
+    if (getSessionFromCookies(req) !== null) {
       return res.redirect(`${env.BACKEND_URL}/auth/callback`);
     }
+    clearAuthCookies(res);
     setPkceCookies(res, code_verifier, state);
     return res.redirect(authRedirect.href);
   } catch (err: any) {
@@ -222,40 +210,22 @@ export async function getDegrees(req: Request, res: Response) {
     // the user: name, email and degrees is stored on the database
 
     // gets userInfo as part of session
-    if (
-      req.cookies.session === undefined ||
-      req.cookies.fingerprint === undefined
-    ) {
+    const sessionData = getSessionFromCookies(req);
+    if (sessionData === null) {
       return res.status(401).json({
         message: "cannot set degrees",
         error: "user session expired",
       });
     }
 
-    const sessionCookie = req.cookies.session;
-    const fingerprintCookie = req.cookies.fingerprint;
-
-    const sessionData = verifyJWT(sessionCookie);
-    if (typeof sessionData === "string") {
+    const parsedSession = ZodUnfinishedUserSession.safeParse(sessionData);
+    if (!parsedSession.success) {
       return res.status(401).json({
         message: "cannot set degrees",
         error: "user session malformed",
       });
     }
-
-    if (!ZodUnfinishedUserSession.safeParse(sessionData).success) {
-      return res.status(401).json({
-        message: "cannot set degrees",
-        error: "user session malformed",
-      });
-    }
-    const session = ZodUnfinishedUserSession.parse(sessionData);
-    if (session.fingerprintHash !== hashFingerprint(fingerprintCookie)) {
-      return res.status(401).json({
-        message: "cannot set degrees",
-        error: "user fingerprint malformed",
-      });
-    }
+    const session = parsedSession.data;
 
     if (
       !namedDegreeZodList("user").min(1).safeParse(req.body.degrees).success ||
@@ -350,27 +320,10 @@ export async function logout(_req: Request, res: Response) {
 export async function checkAuthStatus(req: Request, res: Response) {
   const logger = req.log;
   try {
-    if (
-      req.cookies.session === undefined ||
-      req.cookies.fingerprint === undefined
-    ) {
+    const sessionData = getSessionFromCookies(req);
+    if (sessionData === null) {
       return res.status(401).json({
         message: "user not logged in",
-      });
-    }
-
-    const sessionCookie = req.cookies.session;
-    const fingerprintCookie = req.cookies.fingerprint;
-
-    const sessionData = verifyJWT(sessionCookie);
-
-    if (
-      typeof sessionData === "string" ||
-      sessionData.fingerprintHash !== hashFingerprint(fingerprintCookie)
-    ) {
-      return res.status(401).json({
-        message: "user session malformed",
-        error: "user session malformed",
       });
     }
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,71 +1,27 @@
-import { createHash } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
-import jwt from "jsonwebtoken";
-import { env } from "../config/server.js";
 import { ZodFinishedUserSession } from "../types/auth.js";
+import { getSessionFromCookies } from "../utils/authUtils.js";
 
 export const authenticate = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  try {
-    if (
-      req.cookies.session === undefined ||
-      req.cookies.fingerprint === undefined
-    ) {
-      return res.status(401).json({
-        message: "unauthorized",
-        error: "user session expired",
-      });
-    }
-
-    const sessionCookie = req.cookies.session;
-    const fingerprintCookie = req.cookies.fingerprint;
-
-    const sessionData = jwt.verify(
-      sessionCookie,
-      Buffer.from(env.JWT_PUBLIC_KEY, "base64"),
-      {
-        algorithms: ["RS256"],
-      },
-    );
-
-    if (typeof sessionData === "string") {
-      return res.status(401).json({
-        message: "user session malformed",
-        error: "user session malformed",
-      });
-    }
-
-    if (
-      sessionData.fingerprintHash !==
-      createHash("sha256").update(fingerprintCookie).digest("base64url")
-    ) {
-      return res.status(401).json({
-        message: "user session malformed",
-        error: "user fingerprint malformed",
-      });
-    }
-
-    const parsedSession = ZodFinishedUserSession.safeParse(sessionData);
-    if (!parsedSession.success) {
-      return res.status(401).json({
-        message: "unauthorized",
-        error: "user session malformed",
-      });
-    }
-    req.session = parsedSession.data;
-    return next();
-  } catch (error) {
-    // jwt.verify throws JsonWebTokenError (and its TokenExpiredError
-    // subclass) for expired or otherwise invalid sessions
-    if (error instanceof jwt.JsonWebTokenError) {
-      return res.status(401).json({
-        message: "unauthorized",
-        error: "invalid user session",
-      });
-    }
-    return res.status(500).json(JSON.stringify(error));
+  const sessionData = getSessionFromCookies(req);
+  if (sessionData === null) {
+    return res.status(401).json({
+      message: "unauthorized",
+      error: "invalid user session",
+    });
   }
+
+  const parsedSession = ZodFinishedUserSession.safeParse(sessionData);
+  if (!parsedSession.success) {
+    return res.status(401).json({
+      message: "unauthorized",
+      error: "user session malformed",
+    });
+  }
+  req.session = parsedSession.data;
+  return next();
 };

--- a/backend/src/utils/authUtils.ts
+++ b/backend/src/utils/authUtils.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { env } from "../config/server.js";
 
@@ -63,6 +63,31 @@ export const verifyJWT = (token: string) => {
 
 export const hashFingerprint = (fingerprintCookie: string) =>
   createHash("sha256").update(fingerprintCookie).digest("base64url");
+
+// verifies the session + fingerprint cookie pair and returns the decoded
+// session payload. returns null when the cookies are missing, the jwt is
+// expired or invalid, or the fingerprint doesn't match
+export const getSessionFromCookies = (req: Request): jwt.JwtPayload | null => {
+  const sessionCookie = req.cookies.session;
+  const fingerprintCookie = req.cookies.fingerprint;
+  if (sessionCookie === undefined || fingerprintCookie === undefined) {
+    return null;
+  }
+
+  try {
+    const sessionData = verifyJWT(sessionCookie);
+    if (
+      typeof sessionData === "string" ||
+      sessionData.fingerprintHash !== hashFingerprint(fingerprintCookie)
+    ) {
+      return null;
+    }
+    return sessionData;
+  } catch {
+    // verifyJWT throws on expired or otherwise invalid tokens
+    return null;
+  }
+};
 
 const PKCE_COOKIE_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
 


### PR DESCRIPTION
Session verification (cookies, JWT verify, fingerprint match) was implemented four times across the auth middleware and controllers, with drift: the middleware inlined its own `jwt.verify` and `createHash` instead of using the shared helpers. Extracts `getSessionFromCookies` into authUtils and uses it in all four places.

One deliberate behavior change: an expired or malformed JWT used to 500 in the three controller paths (the middleware already 401'd); now every path treats it as an invalid session (401, or a restart of the login flow). A couple of 401 message strings got unified along the way.

Stacked on #278, retarget to master once that merges. Verified on the dev profile: protected route without cookies 401s from the middleware, `/api/auth/check` triages logged-out correctly, login redirect still issues per-request PKCE cookies. biome and tsc clean.
