### PR TITLE
feat: let non-UG emails sign up with sentinel batch and degree

### DIFF
--- a/backend/src/controllers/timetable/copyTimetable.ts
+++ b/backend/src/controllers/timetable/copyTimetable.ts
@@ -45,7 +45,9 @@ export const copyTimetable = async (req: Request, res: Response) => {
   const isDraft = true;
   const isArchived = false;
   const acadYear = timetableJSON.metadata.acadYear;
-  const year: number = acadYear - author.batch + 1;
+  // batch 0 means the author's email gave no batch; year 0 is a sentinel so
+  // the frontend skips year-based labels and defaults for this timetable
+  const year: number = author.batch === 0 ? 0 : acadYear - author.batch + 1;
   const semester = timetableJSON.metadata.semester;
   const sections: Section[] = [];
   let timings: string[] = [];

--- a/backend/src/controllers/timetable/createTimetable.ts
+++ b/backend/src/controllers/timetable/createTimetable.ts
@@ -25,7 +25,9 @@ export const createTimetable = async (req: Request, res: Response) => {
   const isDraft = true;
   const isArchived = false;
   const acadYear = timetableJSON.metadata.acadYear;
-  const year: number = acadYear - author.batch + 1;
+  // batch 0 means the author's email gave no batch; year 0 is a sentinel so
+  // the frontend skips year-based labels and defaults for this timetable
+  const year: number = author.batch === 0 ? 0 : acadYear - author.batch + 1;
   const semester = timetableJSON.metadata.semester;
   const sections: Section[] = [];
   const timings: string[] = [];

--- a/backend/src/controllers/user/auth.ts
+++ b/backend/src/controllers/user/auth.ts
@@ -182,14 +182,15 @@ export async function authCallback(req: Request, res: Response) {
         setAuthCookies(res, token, fingerprint, maxAge);
 
         const batch = getBatchFromEmail(userData.email);
-        // batch is set to 0000 if it's a non-student email, like hpc@hyderabad.bits-hyderabad.ac.in
-        // or undefined
+        // batch is 0000 for emails that don't follow the f<year> format (hd
+        // students, non-student addresses); their year of study is unknown,
+        // so they pick degrees as if they were first years
+        const yearOfStudy =
+          batch === "0000"
+            ? 1
+            : timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1;
 
-        res.redirect(
-          `${env.FRONTEND_URL}/getDegrees?year=${
-            timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1
-          }`,
-        );
+        res.redirect(`${env.FRONTEND_URL}/getDegrees?year=${yearOfStudy}`);
       }
     }
   } catch (_err: any) {
@@ -394,11 +395,15 @@ export async function checkAuthStatus(req: Request, res: Response) {
 
       const batch = getBatchFromEmail(sessionData.email);
 
+      // same 0000 sentinel handling as the auth callback redirect
+      const yearOfStudy =
+        batch === "0000"
+          ? 1
+          : timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1;
+
       return res.json({
         message: "user needs to get degrees",
-        redirect: `/getDegrees?year=${
-          timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1
-        }`,
+        redirect: `/getDegrees?year=${yearOfStudy}`,
       });
     }
 

--- a/backend/src/controllers/user/auth.ts
+++ b/backend/src/controllers/user/auth.ts
@@ -4,6 +4,7 @@ import {
   getBatchFromEmail,
   isAValidDegreeCombination,
   namedDegreeZodList,
+  unknownDegree,
 } from "lib";
 import * as client from "openid-client";
 import { getConfig } from "../../config/authClient.js";
@@ -25,6 +26,7 @@ import {
   setAuthCookies,
   setPkceCookies,
   signJWT,
+  toTitleCase,
   verifyJWT,
 } from "../../utils/authUtils.js";
 
@@ -176,19 +178,45 @@ export async function authCallback(req: Request, res: Response) {
         setAuthCookies(res, token, fingerprint, maxAge);
         res.redirect(env.FRONTEND_URL);
       } else {
+        const batch = getBatchFromEmail(userData.email);
+
+        if (batch === "0000") {
+          // hd students and other non-f addresses have no batch or degree
+          // defaults to ask for on getDegrees, so they skip it entirely and
+          // get sentinel values instead
+          const createdUser = await userRepository
+            .createQueryBuilder()
+            .insert()
+            .into(User)
+            .values({
+              batch: 0,
+              name: toTitleCase(userData.name),
+              degrees: [unknownDegree],
+              email: userData.email,
+              timetables: [],
+            })
+            .execute();
+
+          const finishedUserData: FinishedUserSession = {
+            name: userData.name,
+            email: userData.email,
+            id: createdUser.identifiers[0].id,
+            fingerprintHash: hashFingerprint(fingerprint),
+          };
+
+          const token = signJWT(finishedUserData, maxAge);
+          clearAuthCookies(res);
+          setAuthCookies(res, token, fingerprint, maxAge);
+          return res.redirect(env.FRONTEND_URL);
+        }
+
         // reset session and set ID as well
         const token = signJWT(userData, maxAge);
         clearAuthCookies(res);
         setAuthCookies(res, token, fingerprint, maxAge);
 
-        const batch = getBatchFromEmail(userData.email);
-        // batch is 0000 for emails that don't follow the f<year> format (hd
-        // students, non-student addresses); their year of study is unknown,
-        // so they pick degrees as if they were first years
         const yearOfStudy =
-          batch === "0000"
-            ? 1
-            : timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1;
+          timetableJSON.metadata.acadYear - Number.parseInt(batch, 10) + 1;
 
         res.redirect(`${env.FRONTEND_URL}/getDegrees?year=${yearOfStudy}`);
       }
@@ -204,18 +232,6 @@ export async function authCallback(req: Request, res: Response) {
 
 export async function getDegrees(req: Request, res: Response) {
   const logger = req.log;
-  // this function is declared outside the try catch block
-  // to make the capitalised name into title case
-
-  function toTitleCase(str: string | undefined) {
-    if (str === undefined) {
-      return "";
-    }
-    return str
-      .split(" ")
-      .map((s) => s[0].toUpperCase() + s.substring(1).toLowerCase())
-      .join(" ");
-  }
 
   try {
     // for user to enter their degrees
@@ -260,6 +276,8 @@ export async function getDegrees(req: Request, res: Response) {
 
     if (
       !namedDegreeZodList("user").min(1).safeParse(req.body.degrees).success ||
+      // the sentinel degree is assigned at signup, never picked here
+      req.body.degrees.includes(unknownDegree) ||
       (req.body.degrees.length === 2 &&
         !isAValidDegreeCombination(req.body.degrees))
     ) {

--- a/backend/src/utils/authUtils.ts
+++ b/backend/src/utils/authUtils.ts
@@ -65,6 +65,16 @@ export const verifyJWT = (token: string) => {
 export const hashFingerprint = (fingerprintCookie: string) =>
   createHash("sha256").update(fingerprintCookie).digest("base64url");
 
+export const toTitleCase = (str: string | undefined) => {
+  if (str === undefined) {
+    return "";
+  }
+  return str
+    .split(" ")
+    .map((s) => s[0].toUpperCase() + s.substring(1).toLowerCase())
+    .join(" ");
+};
+
 const PKCE_COOKIE_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
 
 // stores the per-request pkce verifier and state so the auth callback can

--- a/frontend/src/components/TimetableCard.tsx
+++ b/frontend/src/components/TimetableCard.tsx
@@ -69,8 +69,12 @@ function TimetableCard({ timetable, showFooter }: Props) {
               </span>
               <span>|</span>
               <span>{timetable.degrees.join("")}</span>
-              <span>|</span>
-              <span className="flex-none">{`${timetable.year}-${timetable.semester}`}</span>
+              {timetable.year !== 0 && (
+                <>
+                  <span>|</span>
+                  <span className="flex-none">{`${timetable.year}-${timetable.semester}`}</span>
+                </>
+              )}
             </p>
           </Badge>
         </CardContent>

--- a/frontend/src/components/TimetableCard.tsx
+++ b/frontend/src/components/TimetableCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import type { timetableType } from "lib";
+import { type timetableType, unknownDegree } from "lib";
 import { Edit2, Eye, EyeOff, Trash } from "lucide-react";
 import { useState } from "react";
 import type { z } from "zod";
@@ -67,8 +67,12 @@ function TimetableCard({ timetable, showFooter }: Props) {
                 {timetable.acadYear}-
                 {(timetable.acadYear + 1).toString().slice(2)}
               </span>
-              <span>|</span>
-              <span>{timetable.degrees.join("")}</span>
+              {!timetable.degrees.includes(unknownDegree) && (
+                <>
+                  <span>|</span>
+                  <span>{timetable.degrees.join("")}</span>
+                </>
+              )}
               {timetable.year !== 0 && (
                 <>
                   <span>|</span>

--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -51,8 +51,12 @@ const TimetableHeader = ({
               <span>{timetable.acadYear}</span>
               <span>|</span>
               <span>{timetable.degrees.join("")}</span>
-              <span>|</span>
-              <span className="flex-none">{`${timetable.year}-${timetable.semester}`}</span>
+              {timetable.year !== 0 && (
+                <>
+                  <span>|</span>
+                  <span className="flex-none">{`${timetable.year}-${timetable.semester}`}</span>
+                </>
+              )}
             </p>
           </Badge>
           <span className="lg:text-md md:text-sm text-xs text-muted-foreground">

--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -1,3 +1,4 @@
+import { unknownDegree } from "lib";
 import {
   Copy,
   Download,
@@ -49,8 +50,12 @@ const TimetableHeader = ({
           <Badge variant="default" className="w-fit">
             <p className="flex items-center gap-1">
               <span>{timetable.acadYear}</span>
-              <span>|</span>
-              <span>{timetable.degrees.join("")}</span>
+              {!timetable.degrees.includes(unknownDegree) && (
+                <>
+                  <span>|</span>
+                  <span>{timetable.degrees.join("")}</span>
+                </>
+              )}
               {timetable.year !== 0 && (
                 <>
                   <span>|</span>

--- a/frontend/src/pages/EditUserProfile.tsx
+++ b/frontend/src/pages/EditUserProfile.tsx
@@ -98,14 +98,16 @@ function EditUserProfile() {
         <h5 className="scroll-m-20 text-l tracking-tight lg:text-xl text-foreground">
           {user.email}
         </h5>
-        <div className="flex">
-          <h5 className="scroll-m-20 text-l tracking-tight lg:text-xl text-foregroun mt-4 mb-4 font-bold">
-            Batch:
-          </h5>
-          <h5 className="scroll-m-20 text-l tracking-tight lg:text-xl text-foreground mt-4 mb-2 mx-2">
-            {batch}
-          </h5>
-        </div>
+        {batch !== "0000" && (
+          <div className="flex">
+            <h5 className="scroll-m-20 text-l tracking-tight lg:text-xl text-foregroun mt-4 mb-4 font-bold">
+              Batch:
+            </h5>
+            <h5 className="scroll-m-20 text-l tracking-tight lg:text-xl text-foreground mt-4 mb-2 mx-2">
+              {batch}
+            </h5>
+          </div>
+        )}
         <div className="flex sm:flex-row flex-col">
           <DegreeDropDown
             firstDegree={firstDegree}

--- a/frontend/src/pages/EditUserProfile.tsx
+++ b/frontend/src/pages/EditUserProfile.tsx
@@ -1,5 +1,5 @@
 import { Route } from "@tanstack/react-router";
-import { getBatchFromEmail } from "lib";
+import { getBatchFromEmail, unknownDegree } from "lib";
 import { useState } from "react";
 import DegreeDropDown from "@/components/DegreeDropDown";
 import ReportIssue from "@/components/ReportIssue";
@@ -108,21 +108,25 @@ function EditUserProfile() {
             </h5>
           </div>
         )}
-        <div className="flex sm:flex-row flex-col">
-          <DegreeDropDown
-            firstDegree={firstDegree}
-            secondDegree={secondDegree}
-            setFirstDegree={setFirstDegree}
-            setSecondDegree={setSecondDegree}
-            year={undefined}
-          />
-        </div>
-        <Button
-          className="w-fit mt-12 bg-muted font-bold hover:bg-primary-foreground transition ease-in-out text-foreground"
-          onClick={handleSubmit}
-        >
-          Update Profile
-        </Button>
+        {!user.degrees.includes(unknownDegree) && (
+          <>
+            <div className="flex sm:flex-row flex-col">
+              <DegreeDropDown
+                firstDegree={firstDegree}
+                secondDegree={secondDegree}
+                setFirstDegree={setFirstDegree}
+                setSecondDegree={setSecondDegree}
+                year={undefined}
+              />
+            </div>
+            <Button
+              className="w-fit mt-12 bg-muted font-bold hover:bg-primary-foreground transition ease-in-out text-foreground"
+              onClick={handleSubmit}
+            >
+              Update Profile
+            </Button>
+          </>
+        )}
       </div>
       <span className="fixed bottom-0 bg-muted w-full text-center py-1 text-md lg:text-lg text-muted-foreground">
         Powered by CRUx: The Programming and Computing Club of BITS Hyderabad

--- a/lib/src/degrees.ts
+++ b/lib/src/degrees.ts
@@ -31,8 +31,12 @@ export const approvedDegreeList = [
   ...approvedBPharmDegreeList,
 ] as const;
 
+// sentinel degree for users whose email gives no batch (hd students and
+// other non-f addresses); they skip degree selection entirely on signup
+export const unknownDegree = "XX";
+
 export const namedDegreeZodEnum = (name?: string) =>
-  z.enum(approvedDegreeList, {
+  z.enum([...approvedDegreeList, unknownDegree], {
     error: (issue) =>
       issue.input === undefined
         ? addNameToString("degree is required", name)
@@ -94,7 +98,9 @@ export type mscDegreeList = z.infer<typeof mscDegreeZodList>;
 export type bpharmDegreeList = z.infer<typeof bpharmDegreeZodList>;
 
 export const isAValidDegree = (degree: string): degree is degreeEnum => {
-  return approvedDegreeList.includes(degree as degreeEnum);
+  return approvedDegreeList.includes(
+    degree as (typeof approvedDegreeList)[number],
+  );
 };
 export const isAValidBEDegree = (degree: string): degree is beDegreeEnum => {
   return approvedBEDegreeList.includes(degree as beDegreeEnum);

--- a/lib/src/zodEntityTypes.ts
+++ b/lib/src/zodEntityTypes.ts
@@ -3,8 +3,9 @@ import { namedDegreeZodList } from "./degrees.js";
 import { namedSectionTypeZodEnum } from "./sectionTypes.js";
 import {
   addNameToString,
+  namedBatchType,
   namedBooleanType,
-  namedCollegeYearType,
+  namedCollegeYearOrSentinelType,
   namedEmailType,
   namedIntegerType,
   namedISOTimestampType,
@@ -80,7 +81,9 @@ export const namedTimetableType = (name?: string) =>
     private: namedBooleanType(addNameToString("timetable private", name)),
     draft: namedBooleanType(addNameToString("timetable draft", name)),
     archived: namedBooleanType(addNameToString("timetable archived", name)),
-    year: namedCollegeYearType(addNameToString("timetable college year", name)),
+    year: namedCollegeYearOrSentinelType(
+      addNameToString("timetable college year", name),
+    ),
     acadYear: namedYearType(addNameToString("timetable acadYear", name)),
     semester: namedSemesterType(addNameToString("timetable", name)),
     timings: namedNonEmptyStringType(
@@ -104,7 +107,7 @@ export const namedUserType = (name?: string) =>
   z.strictObject({
     id: namedUUIDType(addNameToString("user", name)),
     email: namedEmailType(addNameToString("user", name)),
-    batch: namedYearType(addNameToString("user batch", name)),
+    batch: namedBatchType(addNameToString("user batch", name)),
     name: namedNonEmptyStringType(addNameToString("user name", name)),
     degrees: namedDegreeZodList(addNameToString("user", name)),
     createdAt: namedISOTimestampType(addNameToString("user createdAt", name)),

--- a/lib/src/zodFieldTypes.ts
+++ b/lib/src/zodFieldTypes.ts
@@ -71,6 +71,21 @@ export const namedYearType = (name?: string) =>
     .gte(1900);
 export const yearType = namedYearType();
 
+// batch is a year, or 0 as a sentinel for users whose email gives no batch,
+// like hd or other non-f addresses on the hyderabad domain
+export const namedBatchType = (name?: string) =>
+  z
+    .int({
+      message: addNameToString("batch is an invalid year", name),
+    })
+    .gte(0, {
+      message: addNameToString("batch is an invalid year", name),
+    })
+    .lte(3000, {
+      message: addNameToString("batch is an invalid year", name),
+    });
+export const batchType = namedBatchType();
+
 export const namedCollegeYearType = (name?: string) =>
   z
     .int({
@@ -86,6 +101,21 @@ export const namedCollegeYearType = (name?: string) =>
       message: addNameToString("college year is an invalid year", name),
     });
 export const collegeYearType = namedCollegeYearType();
+
+// college year of a timetable, where 0 is a sentinel for timetables whose
+// author's batch is unknown (see namedBatchType)
+export const namedCollegeYearOrSentinelType = (name?: string) =>
+  z
+    .int({
+      message: addNameToString("college year is an invalid year", name),
+    })
+    .gte(0, {
+      message: addNameToString("college year is an invalid year", name),
+    })
+    .lte(6, {
+      message: addNameToString("college year is an invalid year", name),
+    });
+export const collegeYearOrSentinelType = namedCollegeYearOrSentinelType();
 
 export const namedSemesterType = (name?: string) =>
   z


### PR DESCRIPTION
Lets hd students and other non-f hyderabad emails sign up: they are created directly in the auth callback with batch 0 and a sentinel degree XX, skipping getDegrees entirely. Timetables they create store year 0, and the UI hides batch, degree, and year-sem labels for sentinel values; CDC defaults return nothing for them. The degree zod enum accepts XX but the getDegrees endpoint rejects it so normal signups cannot pick it.

Untested end to end since it needs Logto and a database; tsc and biome pass.