### PR TITLE
fix: drop hover feedback from non-clickable elements

### DIFF
--- a/frontend/src/components/ReportIssue.tsx
+++ b/frontend/src/components/ReportIssue.tsx
@@ -8,8 +8,8 @@ const ReportIssue = ({ error }: { error: string }) => (
     <span className="inline-flex items-baseline gap-1 text-blue-600 dark:text-blue-500 hover:underline">
       <a href="https://github.com/crux-bphc/chronofactorem-rewrite/issues">
         report this issue
+        <ExternalLink className="inline ml-1" size={16} />
       </a>
-      <ExternalLink size={16} />
     </span>
   </span>
 );

--- a/frontend/src/components/TimetableGrid.tsx
+++ b/frontend/src/components/TimetableGrid.tsx
@@ -255,9 +255,9 @@ export function TimetableGrid({
                     {/* biome-ignore lint/a11y/useKeyWithClickEvents: need to check if button works styling wise */}
                     {/** biome-ignore lint/a11y/noStaticElementInteractions: need to check if button works styling wise */}
                     <div
-                      className={`bg-background border border-muted dark:border-muted/70 cursor-pointer transition duration-200 ease-in-out text-foreground/65 p-1.5 ${
-                        isVertical ? "min-h-28 sm:min-h-16" : "min-h-20"
-                      }`}
+                      className={`bg-background border border-muted dark:border-muted/70 transition duration-200 ease-in-out text-foreground/65 p-1.5 ${
+                        isOnEditPage ? "cursor-pointer" : ""
+                      } ${isVertical ? "min-h-28 sm:min-h-16" : "min-h-20"}`}
                       onClick={(event) => handleUnitClick?.(e, event)}
                     >
                       <div className="relative flex h-full text-xs sm:text-sm flex-col justify-end bg-muted-foreground/30 p-1.5 rounded gap-0.5">

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -8,12 +8,10 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+          "border-transparent bg-destructive text-destructive-foreground",
         outline: "text-foreground",
       },
     },


### PR DESCRIPTION
Removes hover feedback from elements that are not clickable: the baked-in hover background on badge variants (the chips on the view and edit timetable pages), the pointer cursor on grid cells on the view page, and the unlinked external-link icon in ReportIssue.

Tested with tsc and biome only.