### PR TITLE
feat: let logged-out visitors view shared timetables

### DIFF
--- a/backend/src/controllers/timetable/getTimetableById.ts
+++ b/backend/src/controllers/timetable/getTimetableById.ts
@@ -32,6 +32,12 @@ export const getTimetableById = async (req: Request, res: Response) => {
       return res.status(404).json({ message: "Timetable does not exist" });
     }
 
+    // drafts only have a valid edit link, so for anyone but the author a
+    // draft behaves like it does not exist
+    if (timetable.draft && req.session?.id !== timetable.authorId) {
+      return res.status(404).json({ message: "Timetable does not exist" });
+    }
+
     return res.json({ ...timetable, id: id });
   } catch (error) {
     logger.error(error);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -4,6 +4,43 @@ import jwt from "jsonwebtoken";
 import { env } from "../config/server.js";
 import { ZodFinishedUserSession } from "../types/auth.js";
 
+// populates req.session when valid auth cookies are present, but never
+// rejects the request; used on routes that serve both logged-in and
+// logged-out users
+export const attachSession = async (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  try {
+    if (req.cookies.session && req.cookies.fingerprint) {
+      const sessionData = jwt.verify(
+        req.cookies.session,
+        Buffer.from(env.JWT_PUBLIC_KEY, "base64"),
+        {
+          algorithms: ["RS256"],
+        },
+      );
+
+      if (
+        typeof sessionData !== "string" &&
+        sessionData.fingerprintHash ===
+          createHash("sha256")
+            .update(req.cookies.fingerprint)
+            .digest("base64url")
+      ) {
+        const parsedSession = ZodFinishedUserSession.safeParse(sessionData);
+        if (parsedSession.success) {
+          req.session = parsedSession.data;
+        }
+      }
+    }
+  } catch {
+    // expired or malformed sessions are treated as logged out
+  }
+  return next();
+};
+
 export const authenticate = async (
   req: Request,
   res: Response,

--- a/backend/src/routers/timetableRouter.ts
+++ b/backend/src/routers/timetableRouter.ts
@@ -28,12 +28,17 @@ import {
   swapSections,
   swapSectionsValidator,
 } from "../controllers/timetable/swapSections.js";
-import { authenticate } from "../middleware/auth.js";
+import { attachSession, authenticate } from "../middleware/auth.js";
 
 const timetableRouter = express.Router();
 
 timetableRouter.post("/create", authenticate, createTimetable);
-timetableRouter.get("/:id", getTimetableByIdValidator, getTimetableById);
+timetableRouter.get(
+  "/:id",
+  attachSession,
+  getTimetableByIdValidator,
+  getTimetableById,
+);
 timetableRouter.post(
   "/:id/delete",
   authenticate,

--- a/frontend/src/components/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableHeader.tsx
@@ -36,8 +36,7 @@ const TimetableHeader = ({
   const { mutate: editTimetable } = useEditTimetable();
   const { mutate: copyTimetable } = useCopyTimetable();
 
-  if (timetable === undefined || user === undefined || courses === undefined)
-    return;
+  if (timetable === undefined || courses === undefined) return;
 
   return (
     <div className="flex justify-between p-4">
@@ -102,7 +101,7 @@ const TimetableHeader = ({
             </TooltipContent>
           </Tooltip>
         )}
-        {!isOnEditPage && user.id === timetable.authorId && (
+        {!isOnEditPage && user?.id === timetable.authorId && (
           <Tooltip>
             <TooltipTrigger
               className={timetable.archived ? "cursor-not-allowed" : ""}
@@ -143,48 +142,50 @@ const TimetableHeader = ({
             </TooltipContent>
           </Tooltip>
         )}
-        <Tooltip>
-          <TooltipTrigger
-            className={timetable.archived ? "cursor-not-allowed" : ""}
-          >
-            <Button
-              disabled={timetable.archived}
-              variant="ghost"
-              className="rounded-full p-3"
-              onClick={() => {
-                dispatch({
-                  type: TimetableActionType.SetIsCopyingTimetable,
-                  isCopyingTimetable: true,
-                });
-                setTimeout(() => {
-                  copyTimetable(timetable.id, {
-                    onSuccess: (res) =>
-                      router.navigate({
-                        to: "/edit/$timetableId",
-                        params: { timetableId: res.data.id },
-                      }),
+        {user !== undefined && (
+          <Tooltip>
+            <TooltipTrigger
+              className={timetable.archived ? "cursor-not-allowed" : ""}
+            >
+              <Button
+                disabled={timetable.archived}
+                variant="ghost"
+                className="rounded-full p-3"
+                onClick={() => {
+                  dispatch({
+                    type: TimetableActionType.SetIsCopyingTimetable,
+                    isCopyingTimetable: true,
                   });
                   setTimeout(() => {
-                    dispatch({
-                      type: TimetableActionType.SetIsCopyingTimetable,
-                      isCopyingTimetable: false,
+                    copyTimetable(timetable.id, {
+                      onSuccess: (res) =>
+                        router.navigate({
+                          to: "/edit/$timetableId",
+                          params: { timetableId: res.data.id },
+                        }),
                     });
+                    setTimeout(() => {
+                      dispatch({
+                        type: TimetableActionType.SetIsCopyingTimetable,
+                        isCopyingTimetable: false,
+                      });
+                    }, 1000);
                   }, 1000);
-                }, 1000);
-              }}
-            >
-              <Copy className="w-5 h-5 md:w-6 md:h-6" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>
-              {timetable.archived
-                ? "Cannot copy archived timetable"
-                : "Copy Timetable"}
-            </p>
-          </TooltipContent>
-        </Tooltip>
-        {user.id === timetable.authorId && (
+                }}
+              >
+                <Copy className="w-5 h-5 md:w-6 md:h-6" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                {timetable.archived
+                  ? "Cannot copy archived timetable"
+                  : "Copy Timetable"}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {user?.id === timetable.authorId && (
           <DeleteTimetableDialog
             timetableId={timetable.id}
             onDeleted={() => router.navigate({ to: "/" })}

--- a/frontend/src/components/TimetablePageShell.tsx
+++ b/frontend/src/components/TimetablePageShell.tsx
@@ -28,7 +28,10 @@ export const timetablePageLoader = async ({
   context: { queryClient: QueryClient };
   params: { timetableId: string };
 }) => {
-  queryClient.ensureQueryData(userQueryOptions);
+  queryClient.ensureQueryData(userQueryOptions).catch(() => {
+    // user is optional on timetable pages: viewing works logged out, so a
+    // failed prefetch here is fine
+  });
   // Courses are fetched for the semester of the timetable, so the timetable
   // has to be loaded first. Awaiting both keeps this data in the loader, so
   // preloading warms it before navigation (see

--- a/frontend/src/data-access/hooks/useUser.ts
+++ b/frontend/src/data-access/hooks/useUser.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import type { timetableType, userWithTimetablesType } from "lib";
 import type z from "zod";
 import chronoAPI from "../axios";
@@ -41,6 +42,13 @@ const fetchUserDetails = async (): Promise<
 export const userQueryOptions = queryOptions({
   queryKey: ["user"],
   queryFn: () => fetchUserDetails(),
+  // a 401 just means the visitor is logged out, so retrying is pointless
+  retry: (failureCount, error) => {
+    if (error instanceof AxiosError && error.response?.status === 401) {
+      return false;
+    }
+    return failureCount < 3;
+  },
   select: (data) => {
     return { ...data, ...filterTimetables(data.timetables) };
   },

--- a/frontend/src/pages/ViewTimetable.tsx
+++ b/frontend/src/pages/ViewTimetable.tsx
@@ -14,15 +14,15 @@ import {
   TimetableProvider,
   useTimetableState,
 } from "@/context";
-import authenticatedRoute from "../AuthenticatedRoute";
 import CenteredSpinner from "../components/CenteredSpinner";
 import NotFound from "../components/NotFound";
 import { SideMenu } from "../components/SideMenu";
 import { TimetableGrid } from "../components/TimetableGrid";
 import { toast } from "../components/ui/use-toast";
+import { rootRoute } from "../router";
 
 const viewTimetableRoute = new Route({
-  getParentRoute: () => authenticatedRoute,
+  getParentRoute: () => rootRoute,
   path: "view/$timetableId",
   loader: timetablePageLoader,
   pendingComponent: CenteredSpinner,
@@ -37,7 +37,7 @@ const viewTimetableRoute = new Route({
 
 function ViewTimetable() {
   const {
-    state: { isVertical, user, courses, timetable, screenIsLarge },
+    state: { isVertical, courses, timetable, screenIsLarge },
     dispatch,
   } = useTimetableState();
 
@@ -97,7 +97,7 @@ function ViewTimetable() {
       });
   }, [screenIsLarge, dispatch, isVertical]);
 
-  if (timetable === undefined || courses === undefined || user === undefined) {
+  if (timetable === undefined || courses === undefined) {
     return <ReportIssue error={"Error fetching queries"} />;
   }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -30,12 +30,12 @@ const routeTree = rootRoute.addChildren([
   loginRoute,
   getDegreesRoute,
   aboutRoute,
+  viewTimetableRoute,
   authenticatedRoute.addChildren([
     homeRoute,
     editUserProfileRoute,
     editTimetableRoute,
     finalizeTimetableRoute,
-    viewTimetableRoute,
   ]),
 ]);
 


### PR DESCRIPTION
Opens /view/:id to logged-out visitors so shared timetable links work regardless of auth. Copy, edit, and delete controls hide for logged-out viewers, and the user query no longer retries 401s. Private timetables stay viewable by link since the link is the access mechanism.

Drafts now 404 for anyone but the author through a new attachSession middleware on GET /api/timetable/:id, matching the frontend convention that drafts only have edit links. Tested with tsc and biome only.