### PR TITLE
feat: allow marking all announcements as read

### DIFF
--- a/frontend/src/components/Announcements.tsx
+++ b/frontend/src/components/Announcements.tsx
@@ -13,6 +13,7 @@ import ReportIssue from "./ReportIssue";
 import Spinner from "./Spinner";
 import { Button } from "./ui/button";
 import { DialogTrigger } from "./ui/dialog";
+import { ToastAction } from "./ui/toast";
 
 function Announcements() {
   const { toast } = useToast();
@@ -29,6 +30,19 @@ function Announcements() {
     );
   }, [readAnnouncements]);
 
+  const markAsRead = (id: string) => {
+    setReadAnnouncements((prev) => [...prev, id]);
+  };
+
+  const markAllAsRead = () => {
+    setReadAnnouncements((prev) => [
+      ...prev,
+      ...(announcements ?? [])
+        .map((announcement) => announcement.id)
+        .filter((id) => !prev.includes(id)),
+    ]);
+  };
+
   useEffect(() => {
     const unreadAnnouncements = announcements?.filter(
       (announcement) => !readAnnouncements.includes(announcement.id),
@@ -40,13 +54,17 @@ function Announcements() {
         description: `You have ${
           unreadAnnouncements.length
         } unread announcement${unreadAnnouncements.length > 1 ? "s" : ""}.`,
+        action: (
+          <ToastAction
+            altText="Mark all announcements as read"
+            onClick={markAllAsRead}
+          >
+            Mark all as read
+          </ToastAction>
+        ),
       });
     }
   }, [announcements, readAnnouncements, toast]);
-
-  const markAsRead = (id: string) => {
-    setReadAnnouncements((prev) => [...prev, id]);
-  };
 
   return (
     <Dialog>
@@ -58,6 +76,18 @@ function Announcements() {
       <DialogContent className="max-h-[400px] overflow-y-scroll">
         <DialogHeader>
           <DialogTitle className="text-xl -mt-1">Announcements</DialogTitle>
+          {announcements?.some(
+            (announcement) => !readAnnouncements.includes(announcement.id),
+          ) && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={markAllAsRead}
+              className="absolute right-10 top-3"
+            >
+              Mark all as read
+            </Button>
+          )}
         </DialogHeader>
         <DialogDescription asChild>
           {isLoading ? (


### PR DESCRIPTION
Adds a Mark all as read button to the announcements dialog header, shown only when unread announcements exist, and as an action on the new-announcements toast on the frontpage.

Tested with tsc and biome only.